### PR TITLE
feat: Add write capabilities to control Figma via MCP

### DIFF
--- a/figma-desktop-bridge/code.js
+++ b/figma-desktop-bridge/code.js
@@ -64,9 +64,379 @@ figma.showUI(__html__, { width: 320, height: 240, visible: true });
   }
 })();
 
-// Listen for requests from UI (e.g., component data requests)
+// Helper function to serialize a variable for response
+function serializeVariable(v) {
+  return {
+    id: v.id,
+    name: v.name,
+    key: v.key,
+    resolvedType: v.resolvedType,
+    valuesByMode: v.valuesByMode,
+    variableCollectionId: v.variableCollectionId,
+    scopes: v.scopes,
+    description: v.description,
+    hiddenFromPublishing: v.hiddenFromPublishing
+  };
+}
+
+// Helper function to serialize a collection for response
+function serializeCollection(c) {
+  return {
+    id: c.id,
+    name: c.name,
+    key: c.key,
+    modes: c.modes,
+    defaultModeId: c.defaultModeId,
+    variableIds: c.variableIds
+  };
+}
+
+// Helper to convert hex color to Figma RGB (0-1 range)
+function hexToFigmaRGB(hex) {
+  // Remove # if present
+  hex = hex.replace(/^#/, '');
+
+  // Parse hex values
+  var r, g, b, a = 1;
+
+  if (hex.length === 3) {
+    r = parseInt(hex[0] + hex[0], 16) / 255;
+    g = parseInt(hex[1] + hex[1], 16) / 255;
+    b = parseInt(hex[2] + hex[2], 16) / 255;
+  } else if (hex.length === 6) {
+    r = parseInt(hex.substring(0, 2), 16) / 255;
+    g = parseInt(hex.substring(2, 4), 16) / 255;
+    b = parseInt(hex.substring(4, 6), 16) / 255;
+  } else if (hex.length === 8) {
+    r = parseInt(hex.substring(0, 2), 16) / 255;
+    g = parseInt(hex.substring(2, 4), 16) / 255;
+    b = parseInt(hex.substring(4, 6), 16) / 255;
+    a = parseInt(hex.substring(6, 8), 16) / 255;
+  } else {
+    throw new Error('Invalid hex color format: ' + hex);
+  }
+
+  return { r: r, g: g, b: b, a: a };
+}
+
+// Listen for requests from UI (e.g., component data requests, write operations)
 figma.ui.onmessage = async (msg) => {
-  if (msg.type === 'GET_COMPONENT') {
+
+  // ============================================================================
+  // EXECUTE_CODE - Arbitrary code execution (Power Tool)
+  // ============================================================================
+  if (msg.type === 'EXECUTE_CODE') {
+    try {
+      console.log('🌉 [Desktop Bridge] Executing code...');
+
+      // Create an async function from the code string
+      // The function has access to 'figma' global
+      var AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+      var fn = new AsyncFunction('figma', msg.code);
+
+      // Execute with timeout
+      var timeoutMs = msg.timeout || 5000;
+      var timeoutPromise = new Promise(function(_, reject) {
+        setTimeout(function() {
+          reject(new Error('Execution timed out after ' + timeoutMs + 'ms'));
+        }, timeoutMs);
+      });
+
+      var result = await Promise.race([
+        fn(figma),
+        timeoutPromise
+      ]);
+
+      console.log('🌉 [Desktop Bridge] Code executed successfully');
+
+      figma.ui.postMessage({
+        type: 'EXECUTE_CODE_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        result: result
+      });
+
+    } catch (error) {
+      console.error('🌉 [Desktop Bridge] Code execution error:', error);
+      figma.ui.postMessage({
+        type: 'EXECUTE_CODE_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: error.message || String(error)
+      });
+    }
+  }
+
+  // ============================================================================
+  // UPDATE_VARIABLE - Update a variable's value in a specific mode
+  // ============================================================================
+  else if (msg.type === 'UPDATE_VARIABLE') {
+    try {
+      console.log('🌉 [Desktop Bridge] Updating variable:', msg.variableId);
+
+      var variable = await figma.variables.getVariableByIdAsync(msg.variableId);
+      if (!variable) {
+        throw new Error('Variable not found: ' + msg.variableId);
+      }
+
+      // Convert value based on variable type
+      var value = msg.value;
+      if (variable.resolvedType === 'COLOR' && typeof value === 'string') {
+        // Convert hex string to Figma color
+        value = hexToFigmaRGB(value);
+      }
+
+      // Set the value for the specified mode
+      variable.setValueForMode(msg.modeId, value);
+
+      console.log('🌉 [Desktop Bridge] Variable updated successfully');
+
+      figma.ui.postMessage({
+        type: 'UPDATE_VARIABLE_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        variable: serializeVariable(variable)
+      });
+
+    } catch (error) {
+      console.error('🌉 [Desktop Bridge] Update variable error:', error);
+      figma.ui.postMessage({
+        type: 'UPDATE_VARIABLE_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: error.message || String(error)
+      });
+    }
+  }
+
+  // ============================================================================
+  // CREATE_VARIABLE - Create a new variable in a collection
+  // ============================================================================
+  else if (msg.type === 'CREATE_VARIABLE') {
+    try {
+      console.log('🌉 [Desktop Bridge] Creating variable:', msg.name);
+
+      // Get the collection
+      var collection = await figma.variables.getVariableCollectionByIdAsync(msg.collectionId);
+      if (!collection) {
+        throw new Error('Collection not found: ' + msg.collectionId);
+      }
+
+      // Create the variable
+      var variable = figma.variables.createVariable(msg.name, collection, msg.resolvedType);
+
+      // Set initial values if provided
+      if (msg.valuesByMode) {
+        for (var modeId in msg.valuesByMode) {
+          var value = msg.valuesByMode[modeId];
+          // Convert hex colors
+          if (msg.resolvedType === 'COLOR' && typeof value === 'string') {
+            value = hexToFigmaRGB(value);
+          }
+          variable.setValueForMode(modeId, value);
+        }
+      }
+
+      // Set description if provided
+      if (msg.description) {
+        variable.description = msg.description;
+      }
+
+      // Set scopes if provided
+      if (msg.scopes) {
+        variable.scopes = msg.scopes;
+      }
+
+      console.log('🌉 [Desktop Bridge] Variable created:', variable.id);
+
+      figma.ui.postMessage({
+        type: 'CREATE_VARIABLE_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        variable: serializeVariable(variable)
+      });
+
+    } catch (error) {
+      console.error('🌉 [Desktop Bridge] Create variable error:', error);
+      figma.ui.postMessage({
+        type: 'CREATE_VARIABLE_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: error.message || String(error)
+      });
+    }
+  }
+
+  // ============================================================================
+  // CREATE_VARIABLE_COLLECTION - Create a new variable collection
+  // ============================================================================
+  else if (msg.type === 'CREATE_VARIABLE_COLLECTION') {
+    try {
+      console.log('🌉 [Desktop Bridge] Creating collection:', msg.name);
+
+      // Create the collection
+      var collection = figma.variables.createVariableCollection(msg.name);
+
+      // Rename the default mode if a name is provided
+      if (msg.initialModeName && collection.modes.length > 0) {
+        collection.renameMode(collection.modes[0].modeId, msg.initialModeName);
+      }
+
+      // Add additional modes if provided
+      if (msg.additionalModes && msg.additionalModes.length > 0) {
+        for (var i = 0; i < msg.additionalModes.length; i++) {
+          collection.addMode(msg.additionalModes[i]);
+        }
+      }
+
+      console.log('🌉 [Desktop Bridge] Collection created:', collection.id);
+
+      figma.ui.postMessage({
+        type: 'CREATE_VARIABLE_COLLECTION_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        collection: serializeCollection(collection)
+      });
+
+    } catch (error) {
+      console.error('🌉 [Desktop Bridge] Create collection error:', error);
+      figma.ui.postMessage({
+        type: 'CREATE_VARIABLE_COLLECTION_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: error.message || String(error)
+      });
+    }
+  }
+
+  // ============================================================================
+  // DELETE_VARIABLE - Delete a variable
+  // ============================================================================
+  else if (msg.type === 'DELETE_VARIABLE') {
+    try {
+      console.log('🌉 [Desktop Bridge] Deleting variable:', msg.variableId);
+
+      var variable = await figma.variables.getVariableByIdAsync(msg.variableId);
+      if (!variable) {
+        throw new Error('Variable not found: ' + msg.variableId);
+      }
+
+      var deletedInfo = {
+        id: variable.id,
+        name: variable.name
+      };
+
+      variable.remove();
+
+      console.log('🌉 [Desktop Bridge] Variable deleted');
+
+      figma.ui.postMessage({
+        type: 'DELETE_VARIABLE_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        deleted: deletedInfo
+      });
+
+    } catch (error) {
+      console.error('🌉 [Desktop Bridge] Delete variable error:', error);
+      figma.ui.postMessage({
+        type: 'DELETE_VARIABLE_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: error.message || String(error)
+      });
+    }
+  }
+
+  // ============================================================================
+  // DELETE_VARIABLE_COLLECTION - Delete a variable collection
+  // ============================================================================
+  else if (msg.type === 'DELETE_VARIABLE_COLLECTION') {
+    try {
+      console.log('🌉 [Desktop Bridge] Deleting collection:', msg.collectionId);
+
+      var collection = await figma.variables.getVariableCollectionByIdAsync(msg.collectionId);
+      if (!collection) {
+        throw new Error('Collection not found: ' + msg.collectionId);
+      }
+
+      var deletedInfo = {
+        id: collection.id,
+        name: collection.name,
+        variableCount: collection.variableIds.length
+      };
+
+      collection.remove();
+
+      console.log('🌉 [Desktop Bridge] Collection deleted');
+
+      figma.ui.postMessage({
+        type: 'DELETE_VARIABLE_COLLECTION_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        deleted: deletedInfo
+      });
+
+    } catch (error) {
+      console.error('🌉 [Desktop Bridge] Delete collection error:', error);
+      figma.ui.postMessage({
+        type: 'DELETE_VARIABLE_COLLECTION_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: error.message || String(error)
+      });
+    }
+  }
+
+  // ============================================================================
+  // REFRESH_VARIABLES - Re-fetch and send all variables data
+  // ============================================================================
+  else if (msg.type === 'REFRESH_VARIABLES') {
+    try {
+      console.log('🌉 [Desktop Bridge] Refreshing variables data...');
+
+      var variables = await figma.variables.getLocalVariablesAsync();
+      var collections = await figma.variables.getLocalVariableCollectionsAsync();
+
+      var variablesData = {
+        success: true,
+        timestamp: Date.now(),
+        fileKey: figma.fileKey || null,
+        variables: variables.map(serializeVariable),
+        variableCollections: collections.map(serializeCollection)
+      };
+
+      // Update the UI's cached data
+      figma.ui.postMessage({
+        type: 'VARIABLES_DATA',
+        data: variablesData
+      });
+
+      // Also send as a response to the request
+      figma.ui.postMessage({
+        type: 'REFRESH_VARIABLES_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        data: variablesData
+      });
+
+      console.log('🌉 [Desktop Bridge] Variables refreshed:', variables.length, 'variables in', collections.length, 'collections');
+
+    } catch (error) {
+      console.error('🌉 [Desktop Bridge] Refresh variables error:', error);
+      figma.ui.postMessage({
+        type: 'REFRESH_VARIABLES_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: error.message || String(error)
+      });
+    }
+  }
+
+  // ============================================================================
+  // GET_COMPONENT - Existing read operation
+  // ============================================================================
+  else if (msg.type === 'GET_COMPONENT') {
     try {
       console.log(`🌉 [Desktop Bridge] Fetching component: ${msg.nodeId}`);
 

--- a/figma-desktop-bridge/ui.html
+++ b/figma-desktop-bridge/ui.html
@@ -97,10 +97,92 @@
     window.__figmaVariablesReady = false;
     window.__figmaComponentData = null;
     window.__figmaComponentRequests = new Map(); // Track pending requests
+    window.__figmaPendingRequests = new Map(); // Track ALL pending requests (generic)
 
     let requestIdCounter = 0;
 
-    // Function to request component data from plugin worker
+    // Generic function to send a command to the plugin worker and wait for response
+    window.sendPluginCommand = (type, params, timeoutMs) => {
+      timeoutMs = timeoutMs || 15000;
+      return new Promise((resolve, reject) => {
+        const requestId = `${type.toLowerCase()}_${++requestIdCounter}_${Date.now()}`;
+
+        // Store the promise callbacks
+        window.__figmaPendingRequests.set(requestId, { resolve, reject, type: type });
+
+        // Build the message
+        const message = Object.assign({ type: type, requestId: requestId }, params || {});
+
+        // Send request to plugin worker
+        parent.postMessage({ pluginMessage: message }, '*');
+
+        console.log('[Desktop Bridge] Sent command:', type, 'requestId:', requestId);
+
+        // Timeout
+        setTimeout(() => {
+          if (window.__figmaPendingRequests.has(requestId)) {
+            window.__figmaPendingRequests.delete(requestId);
+            reject(new Error(type + ' request timed out after ' + timeoutMs + 'ms'));
+          }
+        }, timeoutMs);
+      });
+    };
+
+    // ============================================================================
+    // WRITE OPERATION FUNCTIONS - Exposed for Puppeteer/MCP access
+    // ============================================================================
+
+    // Execute arbitrary code in plugin context
+    window.executeCode = (code, timeout) => {
+      return window.sendPluginCommand('EXECUTE_CODE', { code: code, timeout: timeout || 5000 }, (timeout || 5000) + 2000);
+    };
+
+    // Update a variable's value
+    window.updateVariable = (variableId, modeId, value) => {
+      return window.sendPluginCommand('UPDATE_VARIABLE', { variableId: variableId, modeId: modeId, value: value });
+    };
+
+    // Create a new variable
+    window.createVariable = (name, collectionId, resolvedType, options) => {
+      var params = {
+        name: name,
+        collectionId: collectionId,
+        resolvedType: resolvedType
+      };
+      if (options) {
+        if (options.valuesByMode) params.valuesByMode = options.valuesByMode;
+        if (options.description) params.description = options.description;
+        if (options.scopes) params.scopes = options.scopes;
+      }
+      return window.sendPluginCommand('CREATE_VARIABLE', params);
+    };
+
+    // Create a new variable collection
+    window.createVariableCollection = (name, options) => {
+      var params = { name: name };
+      if (options) {
+        if (options.initialModeName) params.initialModeName = options.initialModeName;
+        if (options.additionalModes) params.additionalModes = options.additionalModes;
+      }
+      return window.sendPluginCommand('CREATE_VARIABLE_COLLECTION', params);
+    };
+
+    // Delete a variable
+    window.deleteVariable = (variableId) => {
+      return window.sendPluginCommand('DELETE_VARIABLE', { variableId: variableId });
+    };
+
+    // Delete a variable collection
+    window.deleteVariableCollection = (collectionId) => {
+      return window.sendPluginCommand('DELETE_VARIABLE_COLLECTION', { collectionId: collectionId });
+    };
+
+    // Refresh variables data
+    window.refreshVariables = () => {
+      return window.sendPluginCommand('REFRESH_VARIABLES', {});
+    };
+
+    // Function to request component data from plugin worker (legacy, kept for compatibility)
     window.requestComponentData = (nodeId) => {
       return new Promise((resolve, reject) => {
         const requestId = `component_${++requestIdCounter}_${Date.now()}`;
@@ -150,9 +232,10 @@
           <div class="details">
             <strong>Variables:</strong> ${varCount} in ${collCount} ${collCount === 1 ? 'collection' : 'collections'}<br>
             <strong>Components:</strong> On-demand via MCP<br>
+            <strong>Write ops:</strong> Enabled ✓<br>
             <br>
-            <code style="font-size: 10px; background: #f3f4f6; padding: 2px 6px; border-radius: 4px; display: block; margin-top: 4px;">window.__figmaVariablesData</code>
-            <code style="font-size: 10px; background: #f3f4f6; padding: 2px 6px; border-radius: 4px; display: block; margin-top: 2px;">window.requestComponentData(id)</code>
+            <code style="font-size: 10px; background: #f3f4f6; padding: 2px 6px; border-radius: 4px; display: block; margin-top: 4px;">window.executeCode(code)</code>
+            <code style="font-size: 10px; background: #f3f4f6; padding: 2px 6px; border-radius: 4px; display: block; margin-top: 2px;">window.updateVariable(id, mode, val)</code>
           </div>
         `;
 
@@ -193,6 +276,94 @@
         `;
 
         console.error('[Desktop Bridge] Error:', msg.error);
+
+      // ============================================================================
+      // WRITE OPERATION RESPONSES - Handle results from plugin worker
+      // ============================================================================
+
+      } else if (msg.type === 'EXECUTE_CODE_RESULT') {
+        console.log('[Desktop Bridge] Execute code result:', msg.success ? 'success' : 'error');
+        const request = window.__figmaPendingRequests.get(msg.requestId);
+        if (request) {
+          if (msg.success) {
+            request.resolve({ success: true, result: msg.result });
+          } else {
+            request.reject(new Error(msg.error));
+          }
+          window.__figmaPendingRequests.delete(msg.requestId);
+        }
+
+      } else if (msg.type === 'UPDATE_VARIABLE_RESULT') {
+        console.log('[Desktop Bridge] Update variable result:', msg.success ? 'success' : 'error');
+        const request = window.__figmaPendingRequests.get(msg.requestId);
+        if (request) {
+          if (msg.success) {
+            request.resolve({ success: true, variable: msg.variable });
+          } else {
+            request.reject(new Error(msg.error));
+          }
+          window.__figmaPendingRequests.delete(msg.requestId);
+        }
+
+      } else if (msg.type === 'CREATE_VARIABLE_RESULT') {
+        console.log('[Desktop Bridge] Create variable result:', msg.success ? 'success' : 'error');
+        const request = window.__figmaPendingRequests.get(msg.requestId);
+        if (request) {
+          if (msg.success) {
+            request.resolve({ success: true, variable: msg.variable });
+          } else {
+            request.reject(new Error(msg.error));
+          }
+          window.__figmaPendingRequests.delete(msg.requestId);
+        }
+
+      } else if (msg.type === 'CREATE_VARIABLE_COLLECTION_RESULT') {
+        console.log('[Desktop Bridge] Create collection result:', msg.success ? 'success' : 'error');
+        const request = window.__figmaPendingRequests.get(msg.requestId);
+        if (request) {
+          if (msg.success) {
+            request.resolve({ success: true, collection: msg.collection });
+          } else {
+            request.reject(new Error(msg.error));
+          }
+          window.__figmaPendingRequests.delete(msg.requestId);
+        }
+
+      } else if (msg.type === 'DELETE_VARIABLE_RESULT') {
+        console.log('[Desktop Bridge] Delete variable result:', msg.success ? 'success' : 'error');
+        const request = window.__figmaPendingRequests.get(msg.requestId);
+        if (request) {
+          if (msg.success) {
+            request.resolve({ success: true, deleted: msg.deleted });
+          } else {
+            request.reject(new Error(msg.error));
+          }
+          window.__figmaPendingRequests.delete(msg.requestId);
+        }
+
+      } else if (msg.type === 'DELETE_VARIABLE_COLLECTION_RESULT') {
+        console.log('[Desktop Bridge] Delete collection result:', msg.success ? 'success' : 'error');
+        const request = window.__figmaPendingRequests.get(msg.requestId);
+        if (request) {
+          if (msg.success) {
+            request.resolve({ success: true, deleted: msg.deleted });
+          } else {
+            request.reject(new Error(msg.error));
+          }
+          window.__figmaPendingRequests.delete(msg.requestId);
+        }
+
+      } else if (msg.type === 'REFRESH_VARIABLES_RESULT') {
+        console.log('[Desktop Bridge] Refresh variables result:', msg.success ? 'success' : 'error');
+        const request = window.__figmaPendingRequests.get(msg.requestId);
+        if (request) {
+          if (msg.success) {
+            request.resolve({ success: true, data: msg.data });
+          } else {
+            request.reject(new Error(msg.error));
+          }
+          window.__figmaPendingRequests.delete(msg.requestId);
+        }
       }
     };
   </script>


### PR DESCRIPTION
Implements the ability to modify Figma documents through the MCP server:

**New MCP Tools:**
- `figma_execute` - Execute arbitrary Figma Plugin API code (power tool)
- `figma_update_variable` - Update variable values in specific modes
- `figma_create_variable` - Create new variables in collections
- `figma_create_variable_collection` - Create new collections with modes
- `figma_delete_variable` - Delete variables (with warning)
- `figma_delete_variable_collection` - Delete collections (with warning)

**Architecture:**
- Desktop Bridge plugin now handles write operations via postMessage
- FigmaDesktopConnector extended with write methods
- Two-way communication with request/response tracking
- Timeout handling for code execution safety

**Features:**
- Hex color auto-conversion for COLOR variables
- Support for all variable types (COLOR, FLOAT, STRING, BOOLEAN)
- Mode management for multi-theme design systems
- Arbitrary code execution with configurable timeout