### PR TITLE
fix: Windows entry point detection for local MCP server

### DIFF
--- a/src/local.ts
+++ b/src/local.ts
@@ -21,6 +21,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { fileURLToPath } from "url";
+import { resolve } from "path";
 import { LocalBrowserManager } from "./browser/local.js";
 import { ConsoleMonitor } from "./core/console-monitor.js";
 import { getConfig } from "./core/config.js";
@@ -3072,7 +3074,12 @@ async function main() {
 }
 
 // Run if executed directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Note: On Windows, import.meta.url uses file:/// (3 slashes) while process.argv uses backslashes
+// We normalize both paths to compare correctly across platforms
+const currentFile = fileURLToPath(import.meta.url);
+const entryFile = process.argv[1] ? resolve(process.argv[1]) : "";
+
+if (currentFile === entryFile) {
 	main().catch((error) => {
 		console.error("Fatal error:", error);
 		process.exit(1);


### PR DESCRIPTION
On Windows, `import.meta.url` returns `file:///D:/path/...` (3 slashes) while `process.argv[1]` uses backslashes like `D:\path\...`.

The previous check `import.meta.url === \`file://${process.argv[1]}\`` would never match on Windows because:
- import.meta.url: file:///D:/figma-console-mcp/dist/local.js
- Expected:        file://D:\figma-console-mcp\dist\local.js

This caused main() to never be called, resulting in the MCP server appearing to start but immediately disconnecting after receiving the initialize message from Claude Desktop.

Fix: Use fileURLToPath() and resolve() to normalize both paths before comparison, ensuring cross-platform compatibility.