### PR TITLE
docs: fix Windows Figma launch command (works in CMD and PowerShell)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Add to your MCP config (e.g., `.claude.json` or `claude_desktop_config.json`):
 - Get **Figma Personal Access Token**: https://www.figma.com/developers/api#access-tokens
 - Restart Figma Desktop with `--remote-debugging-port=9222`
   - **macOS:** `open -a "Figma" --args --remote-debugging-port=9222`
-  - **Windows:** `start figma://--remote-debugging-port=9222`
+  - **Windows:** `cmd /c "%LOCALAPPDATA%\Figma\Figma.exe" --remote-debugging-port=9222`
 
 **📖 [Complete NPX Setup Guide](docs/NPX-INSTALLATION.md)**
 
@@ -230,9 +230,9 @@ Add this configuration:
 open -a "Figma" --args --remote-debugging-port=9222
 ```
 
-**Windows:**
-```cmd
-start figma://--remote-debugging-port=9222
+**Windows (CMD or PowerShell):**
+```
+cmd /c "%LOCALAPPDATA%\Figma\Figma.exe" --remote-debugging-port=9222
 ```
 
 #### Step 5: Restart Claude Desktop

--- a/docs/NPX-INSTALLATION.md
+++ b/docs/NPX-INSTALLATION.md
@@ -92,7 +92,7 @@ Subsequent runs will use the cached version unless you specify `@latest`.
 2. Quit Figma Desktop completely
 3. Relaunch with debug flag:
    - **macOS:** `open -a "Figma" --args --remote-debugging-port=9222`
-   - **Windows:** `start figma://--remote-debugging-port=9222`
+   - **Windows:** `cmd /c "%LOCALAPPDATA%\Figma\Figma.exe" --remote-debugging-port=9222`
 4. Verify http://localhost:9222 is accessible
 5. Add `FIGMA_ACCESS_TOKEN` to your MCP config (see above)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -146,11 +146,11 @@ npm run build:local
 open -a "Figma" --args --remote-debugging-port=9222
 ```
 
-**Windows:**
-```bash
+**Windows (CMD or PowerShell):**
+```
 # Close Figma completely first (Alt+F4)
-# Then run in Command Prompt:
-start figma://--remote-debugging-port=9222
+# Then run:
+cmd /c "%LOCALAPPDATA%\Figma\Figma.exe" --remote-debugging-port=9222
 ```
 
 #### 5. Verify Setup

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -95,7 +95,7 @@ figma_get_status()
     "setupInstructions": {
       "step1": "QUIT Figma Desktop completely",
       "step2_macOS": "open -a \"Figma\" --args --remote-debugging-port=9222",
-      "step2_windows": "start figma://--remote-debugging-port=9222"
+      "step2_windows": "cmd /c \"%LOCALAPPDATA%\\Figma\\Figma.exe\" --remote-debugging-port=9222"
     },
     "ai_instruction": "CRITICAL: User must restart Figma with the debug flag"
   }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,9 +15,9 @@
 >   ```bash
 >   open -a "Figma" --args --remote-debugging-port=9222
 >   ```
-> - **Windows:** Open Command Prompt and run:
->   ```bash
->   start figma://--remote-debugging-port=9222
+> - **Windows:** Open CMD or PowerShell and run:
+>   ```
+>   cmd /c "%LOCALAPPDATA%\Figma\Figma.exe" --remote-debugging-port=9222
 >   ```
 >
 > **Step 3:** Verify setup worked by visiting http://localhost:9222 in Chrome

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -10,7 +10,7 @@ This guide shows real-world scenarios for using Figma Console MCP in your workfl
 
 **One-time setup:** Quit Figma Desktop and relaunch with:
 - **macOS:** `open -a "Figma" --args --remote-debugging-port=9222`
-- **Windows:** `start figma://--remote-debugging-port=9222`
+- **Windows:** `cmd /c "%LOCALAPPDATA%\Figma\Figma.exe" --remote-debugging-port=9222`
 
 Then open your design file and run your plugin.
 


### PR DESCRIPTION
The `start figma://--remote-debugging-port=9222` protocol handler doesn't work reliably on Windows. Replace with a unified command that works in both CMD and PowerShell:

cmd /c "%LOCALAPPDATA%\Figma\Figma.exe" --remote-debugging-port=9222

Updated in:
- README.md
- docs/NPX-INSTALLATION.md
- docs/SETUP.md
- docs/TOOLS.md
- docs/TROUBLESHOOTING.md
- docs/USE_CASES.md