### PR TITLE
feat: Add team library permission to manifest for enhanced collaboration

### DIFF
--- a/figma-desktop-bridge/manifest.json
+++ b/figma-desktop-bridge/manifest.json
@@ -6,6 +6,7 @@
   "ui": "ui.html",
   "editorType": ["figma", "dev"],
   "capabilities": ["inspect"],
+  "permissions": ["teamlibrary"],
   "documentAccess": "dynamic-page",
   "networkAccess": {
     "allowedDomains": ["none"]


### PR DESCRIPTION
Hey! 👋

I ran into an issue while using the Figma Desktop Bridge with files that pull components from a shared design system library. When trying to access library components, I kept getting this error:

"teamlibrary" permission not specified in manifest.json

Turns out the plugin manifest was missing the `teamlibrary` permission, which is needed for the `figma.teamLibrary` API to work. This API lets you:
- List available library variable collections
- Get variables from library collections  
- Import library components by key

**The fix:** Just added `"permissions": ["teamlibrary"]` to the manifest.

I tested it and everything works as expected now — `figma.teamLibrary.getAvailableLibraryVariableCollectionsAsync()` runs without issues and I can import/instantiate library components through the MCP.

Thanks so much for making this project public! It's been incredibly useful for AI-assisted design workflows. Hopefully this small addition helps others who work with shared design system libraries too. 🙏