### PR TITLE
feat: Allow custom host using env variable FIGMA_WS_HOST

### DIFF
--- a/src/local.ts
+++ b/src/local.ts
@@ -5477,7 +5477,10 @@ return {
 			// Start WebSocket bridge server (always available as fallback transport)
 			const wsPort = parseInt(process.env.FIGMA_WS_PORT || "9223", 10);
 			try {
-				this.wsServer = new FigmaWebSocketServer({ port: wsPort });
+				this.wsServer = new FigmaWebSocketServer({
+					port: wsPort,
+					host: process.env.FIGMA_WS_HOST || 'localhost'
+				});
 				await this.wsServer.start();
 				logger.info({ wsPort }, "WebSocket bridge server started");
 


### PR DESCRIPTION
If using docker to run the mcp, it needs to be bound to 0.0.0.0 instead of localhost, otherwise the host machine won't be able to reach the mcp server, and vice-versa, the mcp-server won't be able to reach Figma Desktop (via Figma Bridge Plugin).