### PR TITLE
feat: Add RELAY_COMMAND support and fix plugin reconnection

### DIFF
--- a/figma-desktop-bridge/ui.html
+++ b/figma-desktop-bridge/ui.html
@@ -798,6 +798,17 @@
 
       // Start WebSocket connection via port scanning
       wsScanAndConnect();
+
+      // Periodic discovery — find new MCP servers and recover from exhausted retries.
+      // Cost: 10 failed TCP SYNs to localhost every 10s (sub-millisecond, negligible).
+      // wsScanAndConnect() already skips ports with active connections.
+      setInterval(function() {
+        if (!isScanning) {
+          wsReconnectAttempts = 0;
+          wsReconnectDelay = 500;
+          wsScanAndConnect();
+        }
+      }, 10000);
     })();
 
     // ============================================================================


### PR DESCRIPTION
## Summary

- **WebSocket RELAY_COMMAND**: External Node.js clients can now send commands through the WebSocket server to the connected plugin without going through the MCP stdio protocol. This enables local tools and scripts to execute Figma plugin commands directly by connecting to the WebSocket and sending `{ type: "RELAY_COMMAND", id, method, params }`.
- **Plugin reconnection fix**: The Desktop Bridge plugin no longer dies after 50 failed reconnect attempts. A 10-second periodic discovery scan ensures the plugin always finds new MCP server instances (e.g., when a new Claude Code session starts on a different port) without requiring a manual restart.

## Motivation

**RELAY_COMMAND**: Currently the only way to execute commands in Figma is through the MCP tool interface. For use cases where external tools need to send code to Figma programmatically, there's no way to do so without going through the LLM's context window. With RELAY_COMMAND, any local Node.js process can connect to the WebSocket server and execute plugin commands directly.

**Reconnection fix**: When running multiple Claude sessions (e.g., Chat + Code tabs), MCP servers bind to ports 9223-9232 via fallback. If the plugin connected to port 9223 and that session ends, the plugin retries 50 times with backoff then stops permanently. A new session on port 9226 is never discovered. Users had to manually restart the plugin each time.

## Changes

### `src/core/websocket-server.ts` (+45 lines, 0 modified)
- Added `handleRelayCommand()` private method - self-contained, receives relay messages, calls existing `sendCommand()`, returns results to the external client
- Added 4-line dispatch check in `handleMessage()` before the existing event handling block
- Cancels the 30-second pending-client timeout for relay clients (they don't send FILE_INFO)

### `figma-desktop-bridge/ui.html` (+11 lines, 0 modified)
- Added `setInterval` at end of WebSocket IIFE that resets reconnect counters and rescans every 10 seconds
- `wsScanAndConnect()` already skips connected ports, so cost is near-zero when everything is healthy (10 failed localhost TCP SYNs = sub-millisecond)

## Design decisions

Both changes are **pure insertions** - no existing lines were modified. This minimizes merge conflict risk with future upstream changes.

## Test plan

- [ ] Start MCP server, connect plugin, verify normal operation unchanged
- [ ] Connect a Node.js WebSocket client and send a RELAY_COMMAND with method EXECUTE_CODE - verify result comes back
- [ ] Send RELAY_COMMAND without id or method - verify error response
- [ ] Start MCP server on port 9223, connect plugin, kill server, start new server on 9226 - verify plugin discovers it within 10 seconds without restart
- [ ] Verify plugin still does fast reconnect (sub-second) when a server restarts on the same port
