### PR TITLE
fix: implement --print-path CLI flag for Desktop Bridge manifest discovery

### DIFF
--- a/src/local.ts
+++ b/src/local.ts
@@ -5613,6 +5613,19 @@ const currentFile = fileURLToPath(import.meta.url);
 const entryFile = process.argv[1] ? realpathSync(resolve(process.argv[1])) : "";
 
 if (currentFile === entryFile) {
+	// Handle --print-path: print the Desktop Bridge manifest path and exit
+	if (process.argv.includes("--print-path")) {
+		const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+		const manifestPath = resolve(packageRoot, "figma-desktop-bridge", "manifest.json");
+		if (existsSync(manifestPath)) {
+			console.log(manifestPath);
+			process.exit(0);
+		} else {
+			console.error("figma-desktop-bridge/manifest.json not found at:", manifestPath);
+			process.exit(1);
+		}
+	}
+
 	main().catch((error) => {
 		console.error("Fatal error:", error);
 		process.exit(1);


### PR DESCRIPTION
## Problem

The `README.md` documents the following command for NPX users to locate the Desktop Bridge plugin manifest:

```bash
npx figma-console-mcp@latest --print-path
```

However, this flag was **never implemented**. When run, the server silently ignores the `--print-path` argument, starts the full MCP server, attempts to connect to Figma Desktop on port 9222 (failing), and hangs — it never prints the path or exits.

This breaks the setup tutorial step where designers need to locate `figma-desktop-bridge/manifest.json` to import the plugin in Figma Desktop.

## Root Cause

The `main()` function in `src/local.ts` does not check `process.argv` for any CLI flags before starting the server. A private `getPluginPath()` method exists and correctly resolves the manifest path, but it was never exposed as a CLI flag.

## Fix

Added a `--print-path` check inside the entry-point guard block (after the `currentFile === entryFile` check), before `main()` is called:

- If `--print-path` is passed: prints the absolute path to `figma-desktop-bridge/manifest.json` and exits with code `0`
- If the manifest file is not found: prints an error and exits with code `1`
- All required imports (`dirname`, `resolve`, `existsSync`, `fileURLToPath`) were already present in the file — no new dependencies needed

## Testing

```bash
# Build
npm run build:local

# Test the fix
node dist/local.js --print-path
# → /path/to/figma-console-mcp/figma-desktop-bridge/manifest.json
# → exits with code 0

# Verify server still starts normally without the flag
node dist/local.js
# → starts MCP server as usual
```