### PR TITLE
fix: detect and terminate zombie MCP processes to prevent port exhaustion

### DIFF
--- a/src/core/port-discovery.ts
+++ b/src/core/port-discovery.ts
@@ -10,8 +10,17 @@
  * which port to connect to. Each instance writes its own file with PID for
  * stale-file detection.
  *
+ * Zombie process detection:
+ *   Active servers refresh their port file every 30s (heartbeat).
+ *   On startup, cleanupStalePortFiles() detects zombies via:
+ *     1. Dead PID — process no longer exists (existing behavior)
+ *     2. Stale heartbeat — lastSeen older than 5 minutes (process frozen/hung)
+ *     3. Age ceiling — startedAt older than 4 hours with no heartbeat (pre-v1.12 compat)
+ *   Zombie processes are terminated with SIGTERM to free their ports.
+ *
  * Data flow:
  *   Server binds port → writes /tmp/figma-console-mcp-{port}.json
+ *   Server heartbeat → refreshes lastSeen every 30s
  *   Plugin scans ports 9223-9232 → connects to first responding server
  *   External tools read port files for discovery
  */
@@ -35,11 +44,22 @@ const PORT_FILE_PREFIX = 'figma-console-mcp-';
 /** Directory for port advertisement files */
 const PORT_FILE_DIR = tmpdir();
 
+/** Maximum age before a port file without heartbeat is considered stale (4 hours) */
+export const MAX_PORT_FILE_AGE_MS = 4 * 60 * 60 * 1000;
+
+/** Maximum time since last heartbeat before a process is considered stale (5 minutes) */
+export const HEARTBEAT_STALE_MS = 5 * 60 * 1000;
+
+/** Interval between heartbeat refreshes (30 seconds) */
+export const HEARTBEAT_INTERVAL_MS = 30 * 1000;
+
 export interface PortFileData {
   port: number;
   pid: number;
   host: string;
   startedAt: string;
+  /** Updated by heartbeat every 30s. Missing in port files from pre-v1.12 instances. */
+  lastSeen?: string;
 }
 
 /**
@@ -68,14 +88,16 @@ export function getPortFilePath(port: number): string {
 
 /**
  * Write a port advertisement file so clients can discover this server instance.
- * Includes PID for stale-file detection.
+ * Includes PID for stale-file detection and lastSeen for heartbeat tracking.
  */
 export function advertisePort(port: number, host: string = 'localhost'): void {
+  const now = new Date().toISOString();
   const data: PortFileData = {
     port,
     pid: process.pid,
     host,
-    startedAt: new Date().toISOString(),
+    startedAt: now,
+    lastSeen: now,
   };
 
   const filePath = getPortFilePath(port);
@@ -84,6 +106,26 @@ export function advertisePort(port: number, host: string = 'localhost'): void {
     logger.info({ port, filePath }, 'Port advertised');
   } catch (error) {
     logger.warn({ port, filePath, error }, 'Failed to write port advertisement file');
+  }
+}
+
+/**
+ * Refresh the lastSeen timestamp in a port advertisement file.
+ * Called periodically as a heartbeat to prove this server is still active.
+ * Non-fatal — heartbeat failures are silently ignored.
+ */
+export function refreshPortAdvertisement(port: number): void {
+  const filePath = getPortFilePath(port);
+  try {
+    if (!existsSync(filePath)) return;
+    const raw = readFileSync(filePath, 'utf-8');
+    const data: PortFileData = JSON.parse(raw);
+    // Only refresh our own port file
+    if (data.pid !== process.pid) return;
+    data.lastSeen = new Date().toISOString();
+    writeFileSync(filePath, JSON.stringify(data, null, 2));
+  } catch {
+    // Best-effort — heartbeat failures are non-fatal
   }
 }
 
@@ -112,6 +154,45 @@ function isProcessAlive(pid: number): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Determine if a port file represents a zombie/stale MCP instance.
+ *
+ * Detection layers:
+ *   1. If lastSeen exists (v1.12+): stale if older than HEARTBEAT_STALE_MS (5 min)
+ *   2. If lastSeen is missing (pre-v1.12): stale if startedAt older than MAX_PORT_FILE_AGE_MS (4h)
+ *
+ * Assumes the owning process IS alive (PID check should happen before calling this).
+ */
+export function isStaleInstance(data: PortFileData): boolean {
+  const now = Date.now();
+
+  // If heartbeat exists, use it — active servers refresh every 30s
+  if (data.lastSeen) {
+    const lastSeenAge = now - new Date(data.lastSeen).getTime();
+    return lastSeenAge > HEARTBEAT_STALE_MS;
+  }
+
+  // No heartbeat (pre-v1.12 instance) — fall back to startup age
+  const startedAge = now - new Date(data.startedAt).getTime();
+  return startedAge > MAX_PORT_FILE_AGE_MS;
+}
+
+/**
+ * Attempt to terminate a process by PID.
+ * Uses SIGTERM for graceful shutdown. On Windows, this calls TerminateProcess
+ * which is immediate and cannot be caught.
+ *
+ * @returns true if the signal was sent successfully, false if the process was already gone
+ */
+function terminateProcess(pid: number): boolean {
+  try {
+    process.kill(pid, 'SIGTERM');
+    return true;
+  } catch {
+    return false; // Process may have already exited
   }
 }
 
@@ -159,8 +240,13 @@ export function discoverActiveInstances(preferredPort: number = DEFAULT_WS_PORT)
 }
 
 /**
- * Clean up all stale port files (dead PIDs).
- * Useful for maintenance and debugging.
+ * Clean up stale port files and terminate zombie MCP processes.
+ *
+ * Runs at startup before port binding. Detects stale instances via:
+ *   1. Dead PID — process no longer exists → delete file
+ *   2. Zombie process — alive but stale (no heartbeat or expired heartbeat)
+ *      → send SIGTERM to free the port, then delete file
+ *   3. Corrupt file — invalid JSON → delete file
  */
 export function cleanupStalePortFiles(): number {
   let cleaned = 0;
@@ -173,10 +259,21 @@ export function cleanupStalePortFiles(): number {
         try {
           const raw = readFileSync(filePath, 'utf-8');
           const data: PortFileData = JSON.parse(raw);
+
           if (!isProcessAlive(data.pid)) {
+            // Dead PID — just clean up the file
             unlinkSync(filePath);
             cleaned++;
-            logger.debug({ port: data.port, pid: data.pid }, 'Cleaned up stale port file');
+            logger.debug({ port: data.port, pid: data.pid }, 'Cleaned up stale port file (dead process)');
+          } else if (data.pid !== process.pid && isStaleInstance(data)) {
+            // Live PID but stale — zombie process, terminate it to free the port
+            logger.info(
+              { port: data.port, pid: data.pid, startedAt: data.startedAt, lastSeen: data.lastSeen },
+              'Detected zombie MCP process — sending SIGTERM to free port',
+            );
+            terminateProcess(data.pid);
+            try { unlinkSync(filePath); } catch { /* best-effort */ }
+            cleaned++;
           }
         } catch {
           // Corrupt file — remove it

--- a/src/local.ts
+++ b/src/local.ts
@@ -46,6 +46,8 @@ import {
 	registerPortCleanup,
 	discoverActiveInstances,
 	cleanupStalePortFiles,
+	refreshPortAdvertisement,
+	HEARTBEAT_INTERVAL_MS,
 } from "./core/port-discovery.js";
 import { registerTokenBrowserApp } from "./apps/token-browser/server.js";
 import { registerDesignSystemDashboardApp } from "./apps/design-system-dashboard/server.js";
@@ -68,6 +70,8 @@ class LocalFigmaConsoleMCP {
 	private wsActualPort: number | null = null;
 	/** The preferred port requested (from env var or default) */
 	private wsPreferredPort: number = DEFAULT_WS_PORT;
+	/** Heartbeat timer that refreshes port file to prove this server is active */
+	private wsHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
 	private config = getConfig();
 
 	// In-memory cache for variables data to avoid MCP token limits
@@ -5466,6 +5470,12 @@ return {
 					advertisePort(boundPort, wsHost);
 					registerPortCleanup(boundPort);
 
+					// Start heartbeat — periodically refresh the port file to prove this server is active.
+					// Other instances use this to detect zombie processes on startup.
+					const heartbeatPort = boundPort;
+					this.wsHeartbeatTimer = setInterval(() => refreshPortAdvertisement(heartbeatPort), HEARTBEAT_INTERVAL_MS);
+					this.wsHeartbeatTimer.unref(); // Don't prevent process exit
+
 					break;
 				} catch (wsError) {
 					const errorMsg = wsError instanceof Error ? wsError.message : String(wsError);
@@ -5568,6 +5578,12 @@ return {
 		logger.info("Shutting down MCP server...");
 
 		try {
+			// Stop heartbeat timer
+			if (this.wsHeartbeatTimer) {
+				clearInterval(this.wsHeartbeatTimer);
+				this.wsHeartbeatTimer = null;
+			}
+
 			// Clean up port advertisement before stopping the server
 			if (this.wsActualPort) {
 				unadvertisePort(this.wsActualPort);

--- a/tests/port-discovery.test.ts
+++ b/tests/port-discovery.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the port discovery module.
  * Covers: port range generation, port file lifecycle, PID validation,
- * stale file cleanup, and multi-instance discovery.
+ * stale file cleanup, zombie detection, heartbeat, and multi-instance discovery.
  */
 
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
@@ -11,6 +11,9 @@ import { WebSocketServer as WSServer } from 'ws';
 import {
   DEFAULT_WS_PORT,
   PORT_RANGE_SIZE,
+  MAX_PORT_FILE_AGE_MS,
+  HEARTBEAT_STALE_MS,
+  HEARTBEAT_INTERVAL_MS,
   getPortRange,
   getPortFilePath,
   advertisePort,
@@ -18,6 +21,9 @@ import {
   readPortFile,
   discoverActiveInstances,
   cleanupStalePortFiles,
+  refreshPortAdvertisement,
+  isStaleInstance,
+  PortFileData,
 } from '../src/core/port-discovery.js';
 import { FigmaWebSocketServer } from '../src/core/websocket-server.js';
 
@@ -83,6 +89,18 @@ describe('Port Discovery Module', () => {
       expect(data!.pid).toBe(process.pid);
       expect(data!.host).toBe('localhost');
       expect(data!.startedAt).toBeTruthy();
+    });
+
+    it('should include lastSeen field in port file', () => {
+      advertisePort(TEST_PORT_BASE, 'localhost');
+
+      const data = readPortFile(TEST_PORT_BASE);
+      expect(data).not.toBeNull();
+      expect(data!.lastSeen).toBeTruthy();
+      // lastSeen should be close to startedAt on initial write
+      const started = new Date(data!.startedAt).getTime();
+      const lastSeen = new Date(data!.lastSeen!).getTime();
+      expect(Math.abs(lastSeen - started)).toBeLessThan(1000);
     });
 
     it('should return null for non-existent port file', () => {
@@ -186,7 +204,7 @@ describe('Port Discovery Module', () => {
       expect(existsSync(filePath)).toBe(false);
     });
 
-    it('should not remove files with live PIDs', () => {
+    it('should not remove files with live PIDs and fresh heartbeat', () => {
       advertisePort(TEST_PORT_BASE, 'localhost');
 
       const cleaned = cleanupStalePortFiles();
@@ -201,6 +219,146 @@ describe('Port Discovery Module', () => {
       const cleaned = cleanupStalePortFiles();
       expect(cleaned).toBeGreaterThanOrEqual(1);
       expect(existsSync(filePath)).toBe(false);
+    });
+
+    it('should not terminate our own process even if stale', () => {
+      // Write a port file for our own PID with old lastSeen
+      const filePath = getPortFilePath(TEST_PORT_BASE);
+      writeFileSync(filePath, JSON.stringify({
+        port: TEST_PORT_BASE,
+        pid: process.pid,
+        host: 'localhost',
+        startedAt: new Date(Date.now() - 10 * 60 * 60 * 1000).toISOString(),
+        lastSeen: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+      }));
+
+      // Should not clean up our own PID
+      const cleaned = cleanupStalePortFiles();
+      // The file should still exist — we never terminate ourselves
+      expect(existsSync(filePath)).toBe(true);
+    });
+  });
+
+  describe('isStaleInstance', () => {
+    it('should detect stale instance with expired heartbeat', () => {
+      const data: PortFileData = {
+        port: TEST_PORT_BASE,
+        pid: process.pid,
+        host: 'localhost',
+        startedAt: new Date().toISOString(),
+        lastSeen: new Date(Date.now() - HEARTBEAT_STALE_MS - 1000).toISOString(),
+      };
+      expect(isStaleInstance(data)).toBe(true);
+    });
+
+    it('should not flag instance with fresh heartbeat', () => {
+      const data: PortFileData = {
+        port: TEST_PORT_BASE,
+        pid: process.pid,
+        host: 'localhost',
+        startedAt: new Date().toISOString(),
+        lastSeen: new Date().toISOString(),
+      };
+      expect(isStaleInstance(data)).toBe(false);
+    });
+
+    it('should detect stale pre-v1.12 instance (no lastSeen) by age', () => {
+      const data: PortFileData = {
+        port: TEST_PORT_BASE,
+        pid: process.pid,
+        host: 'localhost',
+        startedAt: new Date(Date.now() - MAX_PORT_FILE_AGE_MS - 1000).toISOString(),
+      };
+      expect(isStaleInstance(data)).toBe(true);
+    });
+
+    it('should not flag recent pre-v1.12 instance (no lastSeen)', () => {
+      const data: PortFileData = {
+        port: TEST_PORT_BASE,
+        pid: process.pid,
+        host: 'localhost',
+        startedAt: new Date().toISOString(),
+      };
+      expect(isStaleInstance(data)).toBe(false);
+    });
+
+    it('should handle heartbeat just within threshold', () => {
+      const data: PortFileData = {
+        port: TEST_PORT_BASE,
+        pid: process.pid,
+        host: 'localhost',
+        startedAt: new Date(Date.now() - 10 * 60 * 60 * 1000).toISOString(), // 10 hours old
+        lastSeen: new Date(Date.now() - HEARTBEAT_STALE_MS + 30000).toISOString(), // 30s within threshold
+      };
+      expect(isStaleInstance(data)).toBe(false);
+    });
+  });
+
+  describe('refreshPortAdvertisement', () => {
+    it('should update lastSeen in the port file', () => {
+      advertisePort(TEST_PORT_BASE, 'localhost');
+      const before = readPortFile(TEST_PORT_BASE);
+      const beforeLastSeen = before!.lastSeen;
+
+      // Small delay to ensure timestamp differs
+      const now = new Date(Date.now() + 1000);
+      jest.spyOn(global, 'Date').mockImplementationOnce(() => now as any);
+
+      refreshPortAdvertisement(TEST_PORT_BASE);
+
+      jest.restoreAllMocks();
+
+      const after = readPortFile(TEST_PORT_BASE);
+      expect(after).not.toBeNull();
+      expect(after!.lastSeen).toBeTruthy();
+      // The port and PID should not change
+      expect(after!.port).toBe(TEST_PORT_BASE);
+      expect(after!.pid).toBe(process.pid);
+      expect(after!.startedAt).toBe(before!.startedAt);
+    });
+
+    it('should not refresh port file owned by another PID', () => {
+      // Write a port file owned by a different PID
+      const filePath = getPortFilePath(TEST_PORT_BASE);
+      const originalLastSeen = new Date(Date.now() - 60000).toISOString();
+      writeFileSync(filePath, JSON.stringify({
+        port: TEST_PORT_BASE,
+        pid: process.pid + 1000, // Different PID
+        host: 'localhost',
+        startedAt: new Date().toISOString(),
+        lastSeen: originalLastSeen,
+      }));
+
+      refreshPortAdvertisement(TEST_PORT_BASE);
+
+      // lastSeen should not have changed
+      const raw = readFileSync(filePath, 'utf-8');
+      const data = JSON.parse(raw);
+      expect(data.lastSeen).toBe(originalLastSeen);
+    });
+
+    it('should handle missing port file gracefully', () => {
+      // Should not throw
+      expect(() => refreshPortAdvertisement(TEST_PORT_BASE + 99)).not.toThrow();
+    });
+  });
+
+  describe('Constants', () => {
+    it('should have sensible heartbeat timing', () => {
+      // Heartbeat interval should be well under the stale threshold
+      expect(HEARTBEAT_INTERVAL_MS).toBeLessThan(HEARTBEAT_STALE_MS);
+      // At least 5 missed heartbeats before declaring stale
+      expect(HEARTBEAT_STALE_MS / HEARTBEAT_INTERVAL_MS).toBeGreaterThanOrEqual(5);
+    });
+
+    it('should have age ceiling well above heartbeat threshold', () => {
+      expect(MAX_PORT_FILE_AGE_MS).toBeGreaterThan(HEARTBEAT_STALE_MS);
+    });
+
+    it('should export expected constant values', () => {
+      expect(HEARTBEAT_INTERVAL_MS).toBe(30_000);
+      expect(HEARTBEAT_STALE_MS).toBe(5 * 60 * 1000);
+      expect(MAX_PORT_FILE_AGE_MS).toBe(4 * 60 * 60 * 1000);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #20 and #17. Zombie MCP server processes from Claude Desktop's double-spawn bug accumulate across all 10 WebSocket ports (9223-9232), blocking new connections entirely. Users are forced to manually kill processes with `lsof -ti:9223-9232 | xargs kill`.

This PR adds a three-layer zombie detection system:

- **Heartbeat**: Active servers refresh `lastSeen` in their port file every 30 seconds
- **Stale heartbeat detection**: If `lastSeen` is older than 5 minutes, the process is frozen or hung
- **Age ceiling**: Port files from pre-v1.12 instances (no `lastSeen` field) are considered stale after 4 hours

On startup, `cleanupStalePortFiles()` now terminates zombie processes via SIGTERM before attempting port binding, automatically freeing occupied ports.

## Safety

- Never terminates its own PID (explicit guard)
- Backward compatible with pre-v1.12 port files (falls back to 4-hour age check)
- 5-minute stale threshold allows for 10 missed heartbeats before declaring zombie
- Uses SIGTERM (graceful) rather than SIGKILL

## Files changed

- `src/core/port-discovery.ts` — Heartbeat, staleness detection, zombie termination
- `src/local.ts` — Heartbeat timer lifecycle (start on bind, clear on shutdown)
- `tests/port-discovery.test.ts` — 13 new tests (38 total, up from 25)

## Test plan

- [x] `npm run build:local` compiles without errors
- [x] `npm test` — all 346 tests pass (13 new)
- [x] Port file includes `lastSeen` field on creation
- [x] `refreshPortAdvertisement()` updates `lastSeen` only for own PID
- [x] `isStaleInstance()` correctly flags expired heartbeat
- [x] `isStaleInstance()` correctly flags old pre-v1.12 instances
- [x] `cleanupStalePortFiles()` skips own PID even if stale
- [x] Constants have sensible ratios (heartbeat interval < stale threshold < age ceiling)