### PR TITLE
feat: add figma_set_image_fill tool for reliable image fills

### DIFF
--- a/figma-desktop-bridge/code.js
+++ b/figma-desktop-bridge/code.js
@@ -1492,6 +1492,64 @@ figma.ui.onmessage = async (msg) => {
   }
 
   // ============================================================================
+  // SET_IMAGE_FILL - Set an image fill on one or more nodes
+  // Receives raw image bytes (as Array) from ui.html which decodes base64
+  // ============================================================================
+  else if (msg.type === 'SET_IMAGE_FILL') {
+    try {
+      console.log('🌉 [Desktop Bridge] Setting image fill, bytes:', msg.imageBytes.length);
+
+      // Convert the plain array back to Uint8Array
+      var bytes = new Uint8Array(msg.imageBytes);
+
+      // Create the image in Figma
+      var image = figma.createImage(bytes);
+      var imageHash = image.hash;
+
+      var fill = {
+        type: 'IMAGE',
+        scaleMode: msg.scaleMode || 'FILL',
+        imageHash: imageHash
+      };
+
+      // Resolve target nodes
+      var nodeIds = msg.nodeIds || (msg.nodeId ? [msg.nodeId] : []);
+      var updatedCount = 0;
+      var updatedNodes = [];
+
+      for (var i = 0; i < nodeIds.length; i++) {
+        var node = await figma.getNodeByIdAsync(nodeIds[i]);
+        if (node && 'fills' in node) {
+          node.fills = [fill];
+          updatedCount++;
+          updatedNodes.push({ id: node.id, name: node.name });
+        }
+      }
+
+      console.log('🌉 [Desktop Bridge] Image fill applied to', updatedCount, 'node(s), hash:', imageHash);
+
+      figma.ui.postMessage({
+        type: 'SET_IMAGE_FILL_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        imageHash: imageHash,
+        updatedCount: updatedCount,
+        nodes: updatedNodes
+      });
+
+    } catch (error) {
+      var errorMsg = error && error.message ? error.message : String(error);
+      console.error('🌉 [Desktop Bridge] Set image fill error:', errorMsg);
+      figma.ui.postMessage({
+        type: 'SET_IMAGE_FILL_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: errorMsg
+      });
+    }
+  }
+
+  // ============================================================================
   // SET_NODE_STROKES - Set strokes on a node
   // ============================================================================
   else if (msg.type === 'SET_NODE_STROKES') {

--- a/figma-desktop-bridge/ui.html
+++ b/figma-desktop-bridge/ui.html
@@ -406,6 +406,24 @@
         .catch(function(err) { return { success: false, error: err.message || String(err) }; });
     };
 
+    // Set image fill on nodes — decodes base64 in browser context (atob available here)
+    // then sends raw bytes to plugin where figma.createImage() is called
+    window.setImageFill = (nodeIds, imageData, scaleMode) => {
+      // Decode base64 to Uint8Array in browser context where atob() is available
+      var binaryStr = atob(imageData);
+      var bytes = new Uint8Array(binaryStr.length);
+      for (var i = 0; i < binaryStr.length; i++) {
+        bytes[i] = binaryStr.charCodeAt(i);
+      }
+      // Send as plain Array (postMessage can't always transfer typed arrays cleanly)
+      return window.sendPluginCommand('SET_IMAGE_FILL', {
+        nodeIds: Array.isArray(nodeIds) ? nodeIds : [nodeIds],
+        imageBytes: Array.from(bytes),
+        scaleMode: scaleMode || 'FILL'
+      }, 60000)
+        .catch(function(err) { return { success: false, error: err.message || String(err) }; });
+    };
+
     // Set component instance properties (TEXT, BOOLEAN, INSTANCE_SWAP, VARIANT)
     // This is the correct way to update component instances vs direct text node editing
     window.setInstanceProperties = (nodeId, properties) => {
@@ -469,6 +487,7 @@
         'SET_TEXT_CONTENT': function(params) { return window.setTextContent(params.nodeId, params.text, params); },
         'CREATE_CHILD_NODE': function(params) { return window.createChildNode(params.parentId, params.nodeType, params.properties); },
         'CAPTURE_SCREENSHOT': function(params) { return window.captureScreenshot(params.nodeId, params); },
+        'SET_IMAGE_FILL': function(params) { return window.setImageFill(params.nodeIds || params.nodeId, params.imageData, params.scaleMode); },
         'SET_INSTANCE_PROPERTIES': function(params) { return window.setInstanceProperties(params.nodeId, params.properties); },
         'GET_VARIABLES_DATA': function() {
           // Return the cached variables data directly
@@ -927,6 +946,9 @@
         // NEW: Screenshot and instance properties (visual validation loop fix)
         case 'CAPTURE_SCREENSHOT_RESULT':
           handleResult('CAPTURE_SCREENSHOT', 'image');
+          break;
+        case 'SET_IMAGE_FILL_RESULT':
+          handleResult('SET_IMAGE_FILL', 'imageHash');
           break;
         case 'SET_INSTANCE_PROPERTIES_RESULT':
           handleResult('SET_INSTANCE_PROPERTIES', 'instance');

--- a/src/core/figma-connector.ts
+++ b/src/core/figma-connector.ts
@@ -63,6 +63,9 @@ export interface IFigmaConnector {
   captureScreenshot(nodeId: string, options?: any): Promise<any>;
   setInstanceProperties(nodeId: string, properties: any): Promise<any>;
 
+  // Image fill
+  setImageFill(nodeIds: string[], imageData: string, scaleMode?: string): Promise<any>;
+
   // Cache management
   clearFrameCache(): void;
 }

--- a/src/core/figma-desktop-connector.ts
+++ b/src/core/figma-desktop-connector.ts
@@ -1508,4 +1508,25 @@ export class FigmaDesktopConnector implements IFigmaConnector {
       throw error;
     }
   }
+
+  /**
+   * Set image fill on one or more nodes (decodes base64 in browser bridge, sends bytes to plugin)
+   */
+  async setImageFill(nodeIds: string[], imageData: string, scaleMode = 'FILL'): Promise<any> {
+    logger.info({ nodeIds, scaleMode, dataLength: imageData.length }, 'Setting image fill via plugin UI');
+
+    const frame = await this.findPluginUIFrame();
+
+    try {
+      const result = await frame.evaluate(
+        `window.setImageFill(${JSON.stringify(nodeIds)}, ${JSON.stringify(imageData)}, ${JSON.stringify(scaleMode)})`
+      );
+
+      logger.info({ success: result.success, imageHash: result.imageHash }, 'Image fill set');
+      return result;
+    } catch (error) {
+      logger.error({ error, nodeIds }, 'Set image fill failed');
+      throw error;
+    }
+  }
 }

--- a/src/core/websocket-connector.ts
+++ b/src/core/websocket-connector.ts
@@ -271,6 +271,14 @@ export class WebSocketConnector implements IFigmaConnector {
   }
 
   // ============================================================================
+  // Image fill
+  // ============================================================================
+
+  async setImageFill(nodeIds: string[], imageData: string, scaleMode = 'FILL'): Promise<any> {
+    return this.wsServer.sendCommand('SET_IMAGE_FILL', { nodeIds, imageData, scaleMode }, 60000);
+  }
+
+  // ============================================================================
   // Cache management (no-op for WebSocket — no frame cache)
   // ============================================================================
 

--- a/src/local.ts
+++ b/src/local.ts
@@ -19,7 +19,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
-import { realpathSync, existsSync } from "fs";
+import { realpathSync, existsSync, readFileSync } from "fs";
 import { LocalBrowserManager } from "./browser/local.js";
 import { ConsoleMonitor } from "./core/console-monitor.js";
 import { getConfig } from "./core/config.js";
@@ -4144,6 +4144,65 @@ After instantiating components, use figma_take_screenshot to verify the result l
 											error instanceof Error ? error.message : String(error),
 									},
 								),
+							},
+						],
+						isError: true,
+					};
+				}
+			},
+		);
+
+		// Tool: Set Image Fill on nodes
+		this.server.tool(
+			"figma_set_image_fill",
+			"Set an image fill on one or more Figma nodes. The imageData parameter accepts EITHER a base64-encoded " +
+			"image string (JPEG/PNG) OR an absolute file path starting with / (e.g. /tmp/photo.jpg). " +
+			"When a file path is provided, the server reads the image from disk — this is preferred for large " +
+			"images since it avoids parameter truncation. The image is decoded in the browser bridge and passed " +
+			"as raw bytes to the Figma plugin. Requires Desktop Bridge plugin.",
+			{
+				nodeIds: z.array(z.string()).describe("Array of node IDs to apply the image fill to"),
+				imageData: z.string().describe("Base64-encoded image data OR an absolute file path (starting with /) to a JPEG/PNG file on disk"),
+				scaleMode: z.enum(["FILL", "FIT", "CROP", "TILE"]).optional().describe("How the image fills the node (default: FILL)"),
+			},
+			async ({ nodeIds, imageData, scaleMode }) => {
+				try {
+					// If imageData looks like a file path, read from disk (avoids truncation)
+					let resolvedImageData = imageData;
+					if (imageData.startsWith('/') && existsSync(imageData)) {
+						const imageBuffer = readFileSync(imageData);
+						resolvedImageData = imageBuffer.toString('base64');
+						logger.info({ imagePath: imageData, bytes: imageBuffer.length }, 'Read image from disk');
+					}
+					const connector = await this.getDesktopConnector();
+					const result = await connector.setImageFill(nodeIds, resolvedImageData, scaleMode || "FILL");
+
+					if (!result.success) {
+						throw new Error(result.error || "Failed to set image fill");
+					}
+
+					return {
+						content: [
+							{
+								type: "text",
+								text: JSON.stringify({
+									success: true,
+									message: `Image fill applied to ${result.updatedCount || 0} node(s)`,
+									imageHash: result.imageHash,
+									nodes: result.nodes,
+								}),
+							},
+						],
+					};
+				} catch (error) {
+					logger.error({ error }, "Failed to set image fill");
+					return {
+						content: [
+							{
+								type: "text",
+								text: JSON.stringify({
+									error: error instanceof Error ? error.message : String(error),
+								}),
 							},
 						],
 						isError: true,


### PR DESCRIPTION
## Summary

Add a new MCP tool `figma_set_image_fill` that applies image fills to Figma nodes via the Desktop Bridge plugin.

## Problem

There was no dedicated way to set image fills on Figma nodes through the MCP server. The existing `figma_execute` approach required embedding base64 data inside eval'd JavaScript strings, which caused:
- **Truncation** of large images due to parameter size limits
- **No `atob()` in the plugin sandbox** (QuickJS), making base64 decoding impossible in `code.js`
- Heavy JPEG artifacts from aggressive compression needed to fit size constraints

## Solution

A proper `SET_IMAGE_FILL` command pipeline that leverages the 3-layer architecture:

```
MCP Server (local.ts) → WebSocket → Bridge UI (ui.html) → postMessage → Plugin Worker (code.js) → figma.createImage()
```

**Key insight:** `atob()` is available in `ui.html` (browser iframe context) but NOT in `code.js` (QuickJS sandbox). Base64 decoding is done in the bridge UI layer, and raw bytes are passed to the plugin.

The `imageData` parameter accepts either:
- A **base64-encoded string** (JPEG/PNG)
- An **absolute file path** (e.g. `/tmp/photo.jpg`) — the server reads the file from disk, avoiding any parameter truncation

## Changes

| File | Change |
|------|--------|
| `src/core/figma-connector.ts` | Add `setImageFill()` to `IFigmaConnector` interface |
| `src/core/websocket-connector.ts` | Implement `setImageFill()` — sends `SET_IMAGE_FILL` command with 60s timeout |
| `src/core/figma-desktop-connector.ts` | Implement `setImageFill()` for CDP transport |
| `src/local.ts` | Register `figma_set_image_fill` MCP tool with file path detection |
| `figma-desktop-bridge/ui.html` | Add `setImageFill()` with `atob()` decoding, `SET_IMAGE_FILL` method mapping |
| `figma-desktop-bridge/code.js` | Add `SET_IMAGE_FILL` handler — receives raw bytes, calls `figma.createImage()` |

## Testing

Tested with a 24KB JPEG product photo applied to 6 nodes simultaneously — all rendered at full quality with no truncation or artifacts.