### PR TITLE
feat: Cloud Write Relay — full design creation from web AI clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > **Your design system as an API.** Model Context Protocol server that bridges design and development—giving AI assistants complete access to Figma for **extraction**, **creation**, and **debugging**.
 
-> **🆕 v1.11.2 — Design System Kit for AI Code Generators:** Connect your Figma design system to Lovable, v0, and Replit via the remote MCP endpoint. `figma_get_design_system_kit` extracts tokens, component specs, and resolved styles in one call — so AI-generated code builds with your brand. [See changelog →](CHANGELOG.md)
+> **🆕 Cloud Write Relay — Web AI Clients Can Now Design in Figma:** Claude.ai, v0, Replit, and Lovable can now create and modify Figma designs through a cloud relay. No Node.js required — just pair your Desktop Bridge plugin with a 6-character code and get 43 tools including full write access. [See changelog →](CHANGELOG.md)
 
 ## What is this?
 
@@ -20,7 +20,8 @@ Figma Console MCP connects AI assistants (like Claude) to Figma, enabling:
 - **✏️ Design creation** - Create UI components, frames, and layouts directly in Figma
 - **🔧 Variable management** - Create, update, rename, and delete design tokens
 - **⚡ Real-time monitoring** - Watch logs as plugins execute
-- **🔄 Three ways to install** - Remote SSE (OAuth, zero-setup), NPX (npm package), or Local Git (source code)
+- **☁️ Cloud Write Relay** - Web AI clients (Claude.ai, v0, Replit) can design in Figma via cloud pairing
+- **🔄 Four ways to connect** - Remote SSE, Cloud Mode, NPX, or Local Git
 
 ---
 
@@ -33,21 +34,24 @@ Figma Console MCP connects AI assistants (like Claude) to Figma, enabling:
 | I want to... | Setup Method | Time |
 |--------------|--------------|------|
 | **Create and modify designs with AI** | [NPX Setup](#-npx-setup-recommended) (Recommended) | ~10 min |
+| **Design from the web** (Claude.ai, v0, Replit, Lovable) | [Cloud Mode](#-cloud-mode-web-ai-clients) | ~5 min |
 | **Contribute to the project** | [Local Git Setup](#for-contributors-local-git-mode) | ~15 min |
 | **Just explore my design data** (read-only) | [Remote SSE](#-remote-sse-read-only-exploration) | ~2 min |
 
 ### ⚠️ Important: Capability Differences
 
-| Capability | NPX / Local Git | Remote SSE |
-|------------|-----------------|------------|
-| Read design data | ✅ | ✅ |
-| **Create components & frames** | ✅ | ❌ |
-| **Edit existing designs** | ✅ | ❌ |
-| **Manage design tokens/variables** | ✅ | ❌ |
-| Desktop Bridge plugin | ✅ | ❌ |
-| **Total tools available** | **56+** | **16** |
+| Capability | NPX / Local Git | Cloud Mode | Remote SSE |
+|------------|-----------------|------------|------------|
+| Read design data | ✅ | ✅ | ✅ |
+| **Create components & frames** | ✅ | ✅ | ❌ |
+| **Edit existing designs** | ✅ | ✅ | ❌ |
+| **Manage design tokens/variables** | ✅ | ✅ | ❌ |
+| Real-time monitoring (console, selection) | ✅ | ❌ | ❌ |
+| Desktop Bridge plugin | ✅ | ✅ | ❌ |
+| Requires Node.js | Yes | **No** | No |
+| **Total tools available** | **57+** | **43** | **22** |
 
-> **Bottom line:** Remote SSE is **read-only** with ~34% of the tools. If you want AI to actually design in Figma, use NPX Setup.
+> **Bottom line:** Remote SSE is **read-only** with ~38% of the tools. **Cloud Mode** unlocks write access from web AI clients without Node.js. NPX/Local Git gives the full 57+ tools with real-time monitoring.
 
 ---
 
@@ -227,7 +231,53 @@ claude mcp add figma-console -s user -- npx -y mcp-remote@latest https://figma-c
 
 #### Upgrading to Full Capabilities
 
-Ready for design creation? Follow the [NPX Setup](#-npx-setup-recommended) guide above.
+Ready for design creation? Follow the [NPX Setup](#-npx-setup-recommended) guide above, or try [Cloud Mode](#-cloud-mode-web-ai-clients) if you don't want to install Node.js.
+
+**📖 [Complete Setup Guide](docs/setup.md)**
+
+---
+
+### ☁️ Cloud Mode (Web AI Clients)
+
+**Best for:** Using Claude.ai, v0, Replit, or Lovable to create and modify Figma designs — no Node.js required.
+
+**What you get:** 43 tools including full write access — design creation, variable management, component instantiation, and all REST API tools. Only real-time monitoring (console logs, selection tracking, document changes) requires Local Mode.
+
+#### Prerequisites
+
+- [ ] **Figma Desktop** with the Desktop Bridge plugin installed (see [Desktop Bridge setup](#step-3-connect-to-figma-desktop))
+- [ ] **A web AI client** connected to the remote MCP endpoint (see [Remote SSE setup](#-remote-sse-read-only-exploration))
+
+#### How to Connect
+
+1. **Set up Remote SSE** if you haven't already — follow the [Remote SSE](#-remote-sse-read-only-exploration) steps above
+2. **Open the Desktop Bridge plugin** in Figma Desktop (Plugins → Development → Figma Desktop Bridge)
+3. **Tell your AI assistant:**
+   ```
+   Connect to my Figma plugin
+   ```
+4. **The AI gives you a 6-character pairing code** (expires in 5 minutes)
+5. **In the plugin:** Toggle "Cloud Mode" → enter the code → click Connect
+6. **You're paired!** Full write access is now available
+
+#### What You Can Do
+
+Once paired, use natural language to design:
+```
+Create a card component with a header image, title, description, and action button
+Set up a color token collection with Light and Dark modes
+Add a "High Contrast" mode to my existing token collection
+```
+
+#### How It Works
+
+Your AI client sends write commands through the cloud MCP server, which relays them via WebSocket to the Desktop Bridge plugin running in your Figma Desktop. The plugin executes the commands using the Figma Plugin API and returns results back through the same path.
+
+```
+AI Client → Cloud MCP Server → Durable Object Relay → Desktop Bridge Plugin → Figma
+```
+
+> **Variables on any plan:** Cloud Mode uses the Plugin API (not the Enterprise REST API), so variable management works on Free, Pro, and Organization plans.
 
 **📖 [Complete Setup Guide](docs/setup.md)**
 
@@ -235,22 +285,24 @@ Ready for design creation? Follow the [NPX Setup](#-npx-setup-recommended) guide
 
 ## 📊 Installation Method Comparison
 
-| Feature | NPX (Recommended) | Local Git | Remote SSE |
-|---------|-------------------|-----------|------------|
-| **Setup time** | ~10 minutes | ~15 minutes | ~2 minutes |
-| **Total tools** | **56+** | **56+** | **22** (read-only) |
-| **Design creation** | ✅ | ✅ | ❌ |
-| **Variable management** | ✅ | ✅ | ❌ |
-| **Component instantiation** | ✅ | ✅ | ❌ |
-| **Desktop Bridge plugin** | ✅ | ✅ | ❌ |
-| **Variables (no Enterprise)** | ✅ | ✅ | ❌ |
-| **Console logs** | ✅ (zero latency) | ✅ (zero latency) | ✅ |
-| **Read design data** | ✅ | ✅ | ✅ |
-| **Authentication** | PAT (manual) | PAT (manual) | OAuth (automatic) |
-| **Automatic updates** | ✅ (`@latest`) | Manual (`git pull`) | ✅ |
-| **Source code access** | ❌ | ✅ | ❌ |
+| Feature | NPX (Recommended) | Cloud Mode | Local Git | Remote SSE |
+|---------|-------------------|------------|-----------|------------|
+| **Setup time** | ~10 minutes | ~5 minutes | ~15 minutes | ~2 minutes |
+| **Total tools** | **57+** | **43** | **57+** | **22** (read-only) |
+| **Design creation** | ✅ | ✅ | ✅ | ❌ |
+| **Variable management** | ✅ | ✅ | ✅ | ❌ |
+| **Component instantiation** | ✅ | ✅ | ✅ | ❌ |
+| **Real-time monitoring** | ✅ | ❌ | ✅ | ❌ |
+| **Desktop Bridge plugin** | ✅ | ✅ | ✅ | ❌ |
+| **Variables (no Enterprise)** | ✅ | ✅ | ✅ | ❌ |
+| **Console logs** | ✅ (zero latency) | ❌ | ✅ (zero latency) | ✅ |
+| **Read design data** | ✅ | ✅ | ✅ | ✅ |
+| **Requires Node.js** | Yes | **No** | Yes | No |
+| **Authentication** | PAT (manual) | OAuth (automatic) | PAT (manual) | OAuth (automatic) |
+| **Automatic updates** | ✅ (`@latest`) | ✅ | Manual (`git pull`) | ✅ |
+| **Source code access** | ❌ | ❌ | ✅ | ❌ |
 
-> **Key insight:** Remote SSE is read-only with ~34% of the tools. Use NPX for full capabilities.
+> **Key insight:** Remote SSE is read-only. Cloud Mode adds write access for web AI clients without Node.js. NPX/Local Git give the full 57+ tools.
 
 **📖 [Complete Feature Comparison](docs/mode-comparison.md)**
 
@@ -260,7 +312,7 @@ Ready for design creation? Follow the [NPX Setup](#-npx-setup-recommended) guide
 
 After setup, try these prompts:
 
-**Basic test (both modes):**
+**Basic test (all modes):**
 ```
 Navigate to https://www.figma.com and check status
 ```
@@ -269,6 +321,12 @@ Navigate to https://www.figma.com and check status
 ```
 Get design variables from [your Figma file URL]
 ```
+
+**Cloud Mode test:**
+```
+Connect to my Figma plugin
+```
+→ Follow the pairing flow, then try: "Create a simple blue rectangle"
 
 **Plugin test (Local Mode only):**
 ```
@@ -320,7 +378,10 @@ When you first use design system tools:
 - `figma_get_file_data` - Full file structure
 - `figma_get_file_for_plugin` - Optimized file data
 
-### ✏️ Design Creation (Local Mode + Desktop Bridge)
+### ☁️ Cloud Relay
+- `figma_pair_plugin` - Generate a pairing code to connect a Desktop Bridge plugin via the cloud relay
+
+### ✏️ Design Creation (Local Mode + Cloud Mode)
 - `figma_execute` - **Power tool**: Run any Figma Plugin API code to create designs
   - Create frames, shapes, text, components
   - Apply auto-layout, styles, effects
@@ -341,7 +402,7 @@ When you first use design system tools:
 - `figma_check_design_parity` - Compare Figma component specs against code implementation, producing a scored diff report with actionable fix items
 - `figma_generate_component_doc` - Generate platform-agnostic markdown documentation by merging Figma design data with code-side info
 
-### 🔧 Variable Management (Local Mode + Desktop Bridge)
+### 🔧 Variable Management (Local Mode + Cloud Mode)
 - `figma_create_variable_collection` - Create new variable collections with modes
 - `figma_create_variable` - Create COLOR, FLOAT, STRING, or BOOLEAN variables
 - `figma_update_variable` - Update variable values in specific modes
@@ -360,6 +421,13 @@ When you first use design system tools:
 
 ## 📖 Example Prompts
 
+### Cloud Mode (Web AI Clients)
+```
+Connect to my Figma plugin so we can start designing
+Pair with my Figma file and create a login form with email, password, and submit button
+Set up a brand color token collection with Light and Dark modes
+```
+
 ### Plugin Debugging
 ```
 Navigate to my Figma plugin and show me any console errors
@@ -375,7 +443,7 @@ Get the Button component with a visual reference image
 Get the Badge component in reconstruction format for programmatic creation
 ```
 
-### Design Creation (Local Mode)
+### Design Creation (Local Mode + Cloud Mode)
 ```
 Create a success notification card with a checkmark icon and message
 Design a button component with hover and disabled states
@@ -385,7 +453,7 @@ Arrange these button variants into a component set
 Organize my icon variants as a proper component set with the purple border
 ```
 
-### Variable Management (Local Mode)
+### Variable Management (Local Mode + Cloud Mode)
 ```
 Create a new color collection called "Brand Colors" with Light and Dark modes
 Add a primary color variable with value #3B82F6 for Light and #60A5FA for Dark
@@ -412,7 +480,7 @@ Navigate to this file and capture what's on screen
 
 ## 🎨 AI-Assisted Design Creation
 
-> **⚠️ Local Mode Only:** This feature requires the Desktop Bridge plugin and only works with Local Mode installation (NPX or Local Git). Remote Mode is read-only and cannot create or modify designs.
+> **Requires Desktop Bridge:** This feature works with Local Mode (NPX or Local Git) and [Cloud Mode](#-cloud-mode-web-ai-clients). Remote SSE without Cloud Mode pairing is read-only and cannot create or modify designs.
 
 One of the most powerful capabilities of this MCP server is the ability to **design complete UI components and pages directly in Figma through natural language conversation** with any MCP-compatible AI assistant like Claude Desktop or Claude Code.
 
@@ -527,7 +595,9 @@ The **Figma Desktop Bridge** plugin is the recommended way to connect Figma to t
 - `FIGMA_WS_PORT` — Override the preferred WebSocket port (default: 9223). The server will fall back through a 10-port range starting from this value if the preferred port is occupied.
 - `FIGMA_WS_HOST` — Override the WebSocket server bind address (default: `localhost`). Set to `0.0.0.0` when running inside Docker so the host machine can reach the MCP server.
 
-**Plugin Limitation:** Only works in Local Mode (NPX or Local Git). Remote SSE mode cannot access it.
+**Cloud Mode:** The plugin also supports a **Cloud Mode** toggle for pairing with web AI clients (Claude.ai, v0, Replit, Lovable). Toggle "Cloud Mode" in the plugin UI, enter the 6-character pairing code from your AI assistant, and click Connect. See [Cloud Mode](#-cloud-mode-web-ai-clients) for details.
+
+**Plugin Limitation:** In Local Mode, works with NPX or Local Git. In Cloud Mode, pairs with the remote MCP endpoint. Remote SSE without Cloud Mode pairing is read-only.
 
 ---
 
@@ -653,9 +723,10 @@ The architecture supports adding new apps with minimal boilerplate — each app 
 
 ## 🛤️ Roadmap
 
-**Current Status:** v1.11.2 (Stable) - Production-ready with Design System Kit, WebSocket-only connectivity, smart multi-file tracking, 57+ tools, Comments API, and MCP Apps
+**Current Status:** v1.12.0 (Stable) - Production-ready with Cloud Write Relay, Design System Kit, WebSocket-only connectivity, smart multi-file tracking, 57+ tools, Comments API, and MCP Apps
 
 **Recent Releases:**
+- [x] **v1.12.0** - Cloud Write Relay: web AI clients (Claude.ai, v0, Replit, Lovable) can create and modify Figma designs via cloud relay pairing — no Node.js required
 - [x] **v1.11.2** - Screenshot fix: `figma_take_screenshot` works without explicit `nodeId` in WebSocket mode
 - [x] **v1.11.1** - Doc generator fixes: clean markdown tables, Storybook links, property metadata filtering
 - [x] **v1.11.0** - Complete CDP removal, improved multi-file active tracking with focus detection

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,10 @@ Figma Console MCP provides AI assistants with real-time access to Figma for debu
 
 **Best for:** Design system extraction, API-based operations, zero-setup experience
 
+Remote Mode has two sub-modes depending on whether the Desktop Bridge plugin is paired:
+
+#### Read-Only (REST API via OAuth/PAT)
+
 ```mermaid
 flowchart TB
     AI[AI Assistant]
@@ -29,9 +33,27 @@ flowchart TB
 - Design system extraction (variables, styles, components)
 - File structure queries
 - Component images
-- Console log capture (requires local)
-- Design creation (requires Desktop Bridge)
-- Variable management (requires Desktop Bridge)
+
+#### Read + Write (REST API + Cloud Write Relay)
+
+When a user pairs the Desktop Bridge plugin via Cloud Mode, Remote Mode gains full write access through the cloud relay:
+
+```mermaid
+flowchart TB
+    AI[AI Assistant]
+    AI -->|SSE| WORKER[Cloudflare Worker]
+    WORKER --> REST[REST Client]
+    WORKER --> RELAY[Plugin Relay DO]
+    REST -->|HTTPS| API[Figma API]
+    RELAY -->|WebSocket| PLUGIN[Desktop Bridge Plugin]
+    PLUGIN --> FILE[Design File]
+```
+
+**Additional Capabilities (with Cloud Relay):**
+- Design creation via Plugin API
+- Variable CRUD operations
+- Component arrangement and organization
+- Console log capture
 
 ---
 
@@ -127,9 +149,15 @@ The MCP server communicates with the Desktop Bridge via WebSocket:
 
 ### Transport Layer
 
-The MCP server uses a transport abstraction (`IFigmaConnector` interface) backed by WebSocket:
+The MCP server uses a transport abstraction (`IFigmaConnector` interface) with three connector implementations:
 
-#### WebSocket Transport
+| Connector | Class | Mode | Transport |
+|-----------|-------|------|-----------|
+| Local WebSocket | `WebSocketConnector` | Local | `ws://localhost:9223–9232` |
+| Local Desktop | `FigmaDesktopConnector` | Local | CDP fallback |
+| Cloud Relay | `CloudWebSocketConnector` | Remote | Fetch RPC to Durable Object |
+
+#### WebSocket Transport (Local)
 
 The Desktop Bridge Plugin connects via WebSocket on ports 9223–9232. No special Figma launch flags needed.
 
@@ -144,6 +172,17 @@ The Desktop Bridge Plugin connects via WebSocket on ports 9223–9232. No specia
 ```
 MCP Server ←WebSocket (ports 9223–9232)→ Plugin UI (ui.html) ←postMessage→ Plugin Code (code.js) ←figma.*→ Figma
 ```
+
+#### Cloud Relay Transport (Remote)
+
+The `CloudWebSocketConnector` implements the same `IFigmaConnector` interface but routes commands via fetch RPC to the `PluginRelayDO` Durable Object. The DO maintains a persistent WebSocket connection to the Desktop Bridge plugin.
+
+**Communication flow:**
+```
+Cloud MCP Server →fetch RPC→ PluginRelayDO ←WebSocket (wss://)→ Plugin UI (ui.html) ←postMessage→ Plugin Code (code.js) ←figma.*→ Figma
+```
+
+See [Cloud Write Relay](#cloud-write-relay) for full details.
 
 #### Multi-Instance Support (v1.10.0+)
 
@@ -242,6 +281,91 @@ sequenceDiagram
 
 ---
 
+## Cloud Write Relay
+
+The Cloud Write Relay enables web-based AI clients (Claude.ai, v0, Replit, Lovable) to send write commands to Figma through a Cloudflare Durable Object relay. This gives Remote Mode full write capabilities — design creation, variable management, and component arrangement — without requiring a local Node.js process.
+
+### Architecture
+
+```
+AI Client (Claude.ai)
+    │
+    ▼
+Cloud MCP Server (/mcp endpoint on Cloudflare Worker)
+    │
+    ├──► REST Client ──► Figma REST API (read operations)
+    │
+    └──► fetch RPC
+            │
+            ▼
+      PluginRelayDO (Durable Object)
+            │
+            ▼ WebSocket (wss://)
+      Desktop Bridge Plugin (ui.html)
+            │
+            ▼ postMessage
+      Plugin Worker (code.js)
+            │
+            ▼ figma.*
+      Figma Plugin API
+```
+
+### Key Components
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| `PluginRelayDO` | `src/core/cloud-websocket-relay.ts` | Durable Object that brokers WebSocket between cloud server and plugin |
+| `CloudWebSocketConnector` | `src/core/cloud-websocket-connector.ts` | `IFigmaConnector` implementation that routes commands via fetch RPC to the relay DO |
+| `registerWriteTools()` | `src/core/write-tools.ts` | Shared tool registration function used by both local and cloud entry points |
+
+### Pairing Flow
+
+```
+AI Client                    Cloud Server              Relay DO                  Desktop Bridge Plugin
+    │                             │                        │                            │
+    │  figma_pair_plugin          │                        │                            │
+    │ ──────────────────────────► │                        │                            │
+    │                             │  Create relay DO       │                            │
+    │                             │ ─────────────────────► │                            │
+    │                             │  Store code in KV      │                            │
+    │  ◄─── 6-char code ──────── │  (5-min TTL)           │                            │
+    │       (shown to user)       │                        │                            │
+    │                             │                        │                            │
+    │                             │                        │   WebSocket connect        │
+    │                             │                        │   wss://.../ws/pair?code=  │
+    │                             │                        │ ◄──────────────────────────│
+    │                             │                        │   Code validated, paired   │
+    │                             │                        │ ──────────────────────────►│
+    │                             │                        │                            │
+    │  figma_execute(...)         │                        │                            │
+    │ ──────────────────────────► │  fetch RPC             │                            │
+    │                             │ ─────────────────────► │  forward via WebSocket     │
+    │                             │                        │ ──────────────────────────►│
+    │                             │                        │                            │ ──► figma.*
+    │                             │                        │  ◄─── result ─────────────│
+    │                             │  ◄─── result ──────── │                            │
+    │  ◄─── result ────────────── │                        │                            │
+```
+
+### Hibernation-Safe Design
+
+The `PluginRelayDO` uses Cloudflare Durable Object hibernation-safe patterns to minimize costs during idle periods between AI turns:
+
+- **WebSocket retrieval:** Uses `this.ctx.getWebSockets('plugin')` to retrieve active connections after hibernation wake-up, rather than storing WebSocket references in memory.
+- **File info storage:** Connected file information is persisted to DO storage (`this.ctx.storage`), not held in instance variables that would be lost during hibernation.
+- **Wake on message:** The DO wakes from hibernation when either the cloud server sends a fetch RPC or the plugin sends a WebSocket message.
+
+### Tool Registration
+
+`registerWriteTools()` is a shared function that registers all Plugin API write tools (design creation, variable CRUD, component arrangement). It is called from both entry points:
+
+- **`src/local.ts`** — Local mode, tools route through the local `WebSocketConnector`
+- **`src/index.ts`** — Remote/cloud mode, tools route through `CloudWebSocketConnector` to the relay DO
+
+This ensures tool parity between local and cloud modes. The same set of write tools is available regardless of deployment path.
+
+---
+
 ## Security Considerations
 
 ### Authentication
@@ -255,6 +379,14 @@ sequenceDiagram
 - **Plugin Execution:** Runs in Figma's sandboxed plugin environment
 - **Code Validation:** Basic validation before execution
 - **No filesystem access:** Plugin code cannot access local files
+
+### Cloud Relay Security
+
+- **Pairing codes:** Single-use, 6-character codes with a 5-minute TTL stored in Cloudflare KV. Codes are consumed on first use and cannot be replayed.
+- **Session scoping:** Each pairing creates a dedicated Durable Object instance. One plugin connects per relay — no cross-session leakage.
+- **Transport encryption:** All cloud relay traffic uses TLS (`wss://` for the plugin WebSocket, HTTPS for fetch RPC).
+- **Bearer token binding:** After pairing, the relay DO ID is stored in KV keyed by the bearer token (`relay:{bearerToken}`, 24h TTL). Only the authenticated AI client session can route commands to its paired relay.
+- **No persistent data storage:** The relay passes commands through to the plugin and returns results. Design data is not stored in the Durable Object beyond the active session.
 
 ### Data Privacy
 
@@ -320,13 +452,20 @@ npm run test:coverage
 ```
 figma-console-mcp/
 ├── src/
-│   ├── local.ts          # Main MCP server (local mode)
-│   ├── index.ts          # Cloudflare Workers entry (remote mode)
-│   └── types/            # TypeScript definitions
+│   ├── local.ts                          # Main MCP server (local mode)
+│   ├── index.ts                          # Cloudflare Workers entry (remote mode)
+│   ├── core/
+│   │   ├── cloud-websocket-relay.ts      # PluginRelayDO Durable Object
+│   │   ├── cloud-websocket-connector.ts  # CloudWebSocketConnector (IFigmaConnector)
+│   │   ├── write-tools.ts               # Shared write tool registration
+│   │   ├── websocket-connector.ts        # Local WebSocketConnector (IFigmaConnector)
+│   │   ├── websocket-server.ts           # Local WebSocket server
+│   │   └── figma-connector.ts            # IFigmaConnector interface
+│   └── types/                            # TypeScript definitions
 ├── figma-desktop-bridge/
-│   ├── code.ts           # Plugin main code
-│   ├── ui.html           # Plugin UI
-│   └── manifest.json     # Plugin manifest
-├── docs/                 # Documentation
-└── tests/                # Test suites
+│   ├── code.js                           # Plugin worker (Figma API access)
+│   ├── ui.html                           # Plugin UI (local + cloud mode)
+│   └── manifest.json                     # Plugin manifest
+├── docs/                                 # Documentation
+└── tests/                                # Test suites
 ```

--- a/docs/mode-comparison.md
+++ b/docs/mode-comparison.md
@@ -1,6 +1,6 @@
 ---
 title: "Mode Comparison"
-description: "Understand the differences between Remote, Local, and NPX installation methods and when to use each."
+description: "Understand the differences between Remote, Cloud Mode, Local, and NPX installation methods and when to use each."
 ---
 
 # Installation Methods & Execution Modes - Complete Comparison
@@ -9,40 +9,53 @@ This document clarifies the differences between installation methods and executi
 
 ## Understanding the Architecture
 
-The MCP server has **two execution modes** but **three installation methods**:
+The MCP server has **three execution modes** and **four setup methods**:
 
 ### Execution Modes (Where Code Runs)
-1. **Remote Mode** - Runs in Cloudflare Workers (cloud)
-2. **Local Mode** - Runs on your machine (Node.js)
+1. **Remote Mode** - Runs in Cloudflare Workers (cloud, read-only)
+2. **Cloud Mode** - Runs in Cloudflare Workers + Cloud Write Relay (cloud, read/write)
+3. **Local Mode** - Runs on your machine (Node.js, full capabilities)
 
-### Installation Methods (How You Install)
-1. **Remote SSE** - URL-based connection (uses Remote Mode)
-2. **NPX** - npm package distribution (uses Local Mode)
-3. **Local Git** - Source code clone (uses Local Mode)
+### Setup Methods (How You Connect)
+1. **Remote SSE/HTTP** - URL-based connection (uses Remote Mode, read-only)
+2. **Cloud Mode** - Remote endpoint + Cloud Write Relay via Desktop Bridge plugin (uses Cloud Mode)
+3. **NPX** - npm package distribution (uses Local Mode)
+4. **Local Git** - Source code clone (uses Local Mode)
 
 ### Authentication Methods (How You Authenticate)
-1. **OAuth** - Automatic browser-based auth (Remote Mode only)
-2. **Personal Access Token (PAT)** - Manual token setup (NPX + Local Git)
+1. **OAuth** - Automatic browser-based auth (Remote SSE only)
+2. **Personal Access Token (PAT)** - Bearer token (Remote `/mcp` endpoint, Cloud Mode)
+3. **Personal Access Token (PAT)** - Environment variable (NPX + Local Git)
+4. **Pairing Code** - 6-character code to connect Desktop Bridge plugin to cloud relay (Cloud Mode only)
 
-**Key Insight:** Authentication method, NOT installation method, determines setup complexity.
+**Key Insight:** Your choice of mode determines both capability level and setup complexity.
 
 ## 🎯 Quick Decision Guide
 
 ### ⚠️ Critical: Tool Count Differences
 
-| Mode | Tools Available | Capabilities |
-|------|-----------------|--------------|
-| **Local Mode** (NPX or Git) | **56+** | Full read/write — create, edit, delete |
-| **Remote Mode** (SSE) | **22** | Read-only — view data, screenshots, logs |
+| Mode | Tools Available | Write Access | Needs Node.js | Real-time |
+|------|-----------------|--------------|---------------|-----------|
+| **Local Mode** (NPX or Git) | **57+** | Yes | Yes | Yes |
+| **Cloud Mode** (Remote + Relay) | **43** | Yes | No | No |
+| **Remote Mode** (read-only) | **22** | No | No | No |
 
-> **Bottom line:** Remote SSE has ~34% of the tools and cannot create or modify designs.
+> **Bottom line:** Remote mode is read-only (22 tools). Cloud Mode adds write access (43 tools) without Node.js. Local has everything (57+ tools) including real-time monitoring.
 
 ### Use NPX Setup (Recommended for Most Users)
-- ✅ **All 57+ tools** including design creation
+- ✅ **All 57+ tools** including design creation and real-time monitoring
 - ✅ Automatic updates with `@latest`
 - ✅ Desktop Bridge Plugin support (recommended connection — no debug flags needed)
 - ✅ Variables without Enterprise plan
-- ⚠️ Requires `FIGMA_ACCESS_TOKEN` (manual, one-time)
+- ⚠️ Requires Node.js 18+ and `FIGMA_ACCESS_TOKEN` (manual, one-time)
+
+### Use Cloud Mode (Web AI Clients)
+- ✅ **43 tools** — full write access (create, edit, delete) plus REST API reads
+- ✅ No Node.js required — only Figma Desktop with the Desktop Bridge plugin
+- ✅ Works with Claude.ai, v0, Replit, Lovable, any MCP-capable web platform
+- ✅ Variables without Enterprise plan (via Plugin API)
+- ⚠️ Requires pairing the Desktop Bridge plugin via a 6-character code
+- ❌ No real-time selection tracking, document changes, or console streaming
 
 ### Use Local Git (For Contributors)
 - ✅ **All 57+ tools** including design creation
@@ -51,7 +64,7 @@ The MCP server has **two execution modes** but **three installation methods**:
 - ⚠️ Requires `FIGMA_ACCESS_TOKEN` (manual)
 - ⚠️ Manual updates via `git pull && npm run build`
 
-### Use Remote SSE (Read-Only Exploration)
+### Use Remote Mode (Read-Only Exploration)
 - ✅ **TRUE zero-setup** - Just paste a URL
 - ✅ **OAuth authentication** - No manual tokens
 - ✅ Works without Figma Desktop restart
@@ -61,38 +74,45 @@ The MCP server has **two execution modes** but **three installation methods**:
 
 ---
 
-## Installation Methods Comparison
+## Setup Methods Comparison
 
-| Aspect | Remote SSE | NPX | Local Git |
-|--------|-----------|-----|-----------|
-| **Execution** | Cloudflare Workers | Local Node.js | Local Node.js |
-| **Code** | `src/index.ts` | `dist/local.js` (npm) | `dist/local.js` (source) |
-| **Authentication** | OAuth (automatic) | PAT (manual) | PAT (manual) |
-| **Setup Complexity** | ⭐ Zero-setup | ⚠️ Manual token + plugin install | ⚠️ Manual token + plugin install |
-| **Distribution** | URL only | npm package | git clone |
-| **Updates** | Automatic (server-side) | `@latest` auto-updates | Manual `git pull + build` |
-| **Figma Desktop** | Not required | Required (Desktop Bridge Plugin) | Required (Desktop Bridge Plugin) |
-| **Desktop Bridge** | ❌ Not available | ✅ Available | ✅ Available |
-| **Source Access** | No | No | Yes |
-| **Use Case** | Most users | Local execution users | Developers |
+| Aspect | Remote (read-only) | Cloud Mode | NPX | Local Git |
+|--------|-------------------|------------|-----|-----------|
+| **Execution** | Cloudflare Workers | Cloudflare Workers + Relay | Local Node.js | Local Node.js |
+| **Code** | `src/index.ts` | `src/index.ts` + relay | `dist/local.js` (npm) | `dist/local.js` (source) |
+| **Authentication** | OAuth (automatic) | PAT + pairing code | PAT (manual) | PAT (manual) |
+| **Setup Complexity** | ⭐ Zero-setup | Moderate (plugin + pairing) | Manual token + plugin install | Manual token + plugin install |
+| **Distribution** | URL only | URL + plugin | npm package | git clone |
+| **Updates** | Automatic (server-side) | Automatic (server-side) | `@latest` auto-updates | Manual `git pull + build` |
+| **Figma Desktop** | Not required | Required (Desktop Bridge) | Required (Desktop Bridge) | Required (Desktop Bridge) |
+| **Desktop Bridge** | ❌ Not available | ✅ Required for relay | ✅ Available | ✅ Available |
+| **Node.js Required** | No | No | Yes | Yes |
+| **Source Access** | No | No | No | Yes |
+| **Tools** | 22 (read-only) | 43 (read/write) | 57+ (full) | 57+ (full) |
+| **Use Case** | Quick evaluation | Web AI clients | Most users | Developers |
 
 ---
 
 ## Feature Availability Matrix
 
-| Feature | Remote Mode | Local Mode | Notes |
-|---------|-------------|------------|-------|
-| **Console Logs** | ✅ | ✅ | Remote uses Browser Rendering API, Local uses WebSocket via Desktop Bridge Plugin |
-| **Screenshots** | ✅ | ✅ | Both use Figma REST API |
-| **Design System Extraction** | ✅ | ✅ | Variables, components, styles via Figma API |
-| **OAuth Authentication** | ✅ | ❌ | Remote has automatic OAuth, Local requires Personal Access Token |
-| **Zero Setup** | ✅ | ❌ | Remote: just paste URL. Local: requires Node.js, build, Figma restart |
-| **Figma Desktop Bridge Plugin** | ❌ | ✅ | **Plugin ONLY works in Local Mode** |
-| **Variables without Enterprise API** | ❌ | ✅ | Requires Desktop Bridge plugin (Local only) |
-| **Reliable Component Descriptions** | ⚠️ | ✅ | API has bugs, plugin method (Local) is reliable |
-| **Zero-Latency Console Logs** | ❌ | ✅ | Local connects via WebSocket (ports 9223–9232) |
-| **Works Behind Corporate Firewall** | ⚠️ | ✅ | Remote requires internet, Local works offline |
-| **Multi-User Shared Token** | ✅ | ❌ | Remote uses per-user OAuth, Local uses single PAT |
+| Feature | Remote (read-only) | Cloud Mode | Local Mode | Notes |
+|---------|-------------------|------------|------------|-------|
+| **Read Design Data** | ✅ | ✅ | ✅ | All modes use Figma REST API |
+| **Design Creation (write)** | ❌ | ✅ | ✅ | Cloud via relay, Local via WebSocket |
+| **Variable Management** | ⚠️ | ✅ | ✅ | Remote requires Enterprise. Cloud/Local use Plugin API (any plan) |
+| **Screenshots** | ✅ | ✅ | ✅ | All use Figma REST API |
+| **Design System Extraction** | ✅ | ✅ | ✅ | Variables, components, styles via Figma API |
+| **Desktop Bridge Plugin** | ❌ | ✅ (required) | ✅ | Plugin required for Cloud relay and Local write access |
+| **Real-time Selection Tracking** | ❌ | ❌ | ✅ | Local-only — requires persistent WebSocket |
+| **Document Change Monitoring** | ❌ | ❌ | ✅ | Local-only — requires persistent WebSocket |
+| **Console Log Streaming** | ❌ | ❌ | ✅ | Local-only — zero-latency via WebSocket |
+| **Console Logs (on-demand)** | ✅ | ✅ | ✅ | Remote uses Browser Rendering API |
+| **OAuth Authentication** | ✅ | ❌ | ❌ | Remote SSE only |
+| **Zero Setup** | ✅ | ❌ | ❌ | Remote: just paste URL |
+| **No Node.js Required** | ✅ | ✅ | ❌ | Cloud Mode only needs Figma Desktop + plugin |
+| **Reliable Component Descriptions** | ⚠️ | ✅ | ✅ | API has bugs; plugin method is reliable |
+| **Works Behind Corporate Firewall** | ⚠️ | ⚠️ | ✅ | Remote/Cloud require internet, Local works offline |
+| **Multi-User Shared Token** | ✅ | ❌ | ❌ | Remote uses per-user OAuth |
 
 ### Legend
 - ✅ Available
@@ -103,7 +123,7 @@ The MCP server has **two execution modes** but **three installation methods**:
 
 ## Architecture Comparison
 
-### Remote Mode Architecture
+### Remote Mode Architecture (Read-Only)
 ```
 Claude Desktop/Code
     ↓ (SSE over HTTPS)
@@ -121,8 +141,32 @@ Figma Files & Design Data
 - Cannot access `localhost` on your machine
 - OAuth tokens stored in Cloudflare KV
 - ~10-30s cold start for first request
+- 22 read-only tools
 
-### Local Mode Architecture
+### Cloud Mode Architecture (Read/Write via Relay)
+```
+Claude.ai / v0 / Replit / Lovable
+    ↓ (Streamable HTTP)
+Cloudflare Workers MCP Server (/mcp)
+    ↓ (fetch RPC)
+Plugin Relay Durable Object
+    ↓ (WebSocket)
+Desktop Bridge Plugin (ui.html)
+    ↓ (postMessage)
+Plugin Worker (code.js)
+    ↓ (Plugin API)
+Figma Design Data
+```
+
+**Key Points:**
+- No Node.js required — relay runs entirely in Cloudflare Workers
+- Desktop Bridge plugin connects to the cloud relay via WebSocket
+- Pairing flow: AI generates 6-character code → user enters in plugin → connected
+- 43 tools: 1 pairing + 27 write tools + 15 REST API reads
+- Variables work on any Figma plan (uses Plugin API, not Enterprise REST API)
+- Pairing code expires after 5 minutes
+
+### Local Mode Architecture (Full Capabilities)
 ```
 Claude Desktop/Code/Cursor/Windsurf
     ↓ (stdio transport)
@@ -139,6 +183,7 @@ Variables & Components Data
 - All 57+ tools work through WebSocket
 - Plugin can access local variables (no Enterprise API needed)
 - Instant console log capture via WebSocket
+- Real-time selection tracking and document change monitoring
 
 ---
 
@@ -178,7 +223,7 @@ Variables & Components Data
 
 ## Prerequisites & Setup Time
 
-### Remote SSE
+### Remote (Read-Only)
 **Prerequisites:** None
 
 **Setup Time:** 2 minutes
@@ -188,6 +233,21 @@ Variables & Components Data
 2. Click "Add Custom Connector"
 3. Paste URL: `https://figma-console-mcp.southleft.com/sse`
 4. Done ✅ (OAuth happens automatically on first API use)
+
+### Cloud Mode
+**Prerequisites:**
+- Figma Desktop installed
+- Desktop Bridge plugin imported and running in your file
+- A web AI client connected to `https://figma-console-mcp.southleft.com/mcp` (with Figma PAT as Bearer token)
+
+**Setup Time:** 5 minutes
+
+**Steps:**
+1. Connect your web AI client to the `/mcp` endpoint with your Figma PAT
+2. Tell your AI to connect to your Figma plugin (natural language)
+3. AI generates a 6-character pairing code
+4. In the Desktop Bridge plugin, toggle "Cloud Mode" and enter the code
+5. Done ✅ — 43 tools with full write access
 
 ### NPX
 **Prerequisites:**
@@ -225,9 +285,9 @@ Variables & Components Data
 
 ## Authentication Comparison
 
-### Remote SSE - OAuth (Automatic) ⭐ Recommended
+### Remote SSE - OAuth (Automatic) ⭐ Simplest
 
-**Method:** Remote Mode only
+**Method:** Remote read-only mode (SSE endpoint)
 
 **How it works:**
 1. First design system tool call triggers OAuth
@@ -245,6 +305,28 @@ Variables & Components Data
 **Limitations:**
 - ⚠️ Requires internet connection
 - ⚠️ Initial authorization flow required (one-time)
+- ❌ Read-only — no write access
+
+### Cloud Mode - PAT + Pairing Code
+
+**Method:** Cloud Mode with write relay
+
+**How it works:**
+1. User creates PAT and provides it as Bearer token when connecting to `/mcp` endpoint
+2. AI generates a 6-character pairing code (valid for 5 minutes)
+3. User enters code in Desktop Bridge plugin (Cloud Mode toggle)
+4. Relay authenticates the plugin-to-cloud connection
+5. All write operations flow through the authenticated relay
+
+**Benefits:**
+- ✅ Write access without Node.js
+- ✅ Pairing code adds a second factor of trust (plugin must be in the right file)
+- ✅ Variables on any Figma plan via Plugin API
+
+**Limitations:**
+- ❌ Manual PAT creation required
+- ❌ Pairing code expires after 5 minutes
+- ⚠️ Must re-pair if connection drops
 
 ### NPX + Local Git - Personal Access Token (Manual)
 
@@ -260,6 +342,7 @@ Variables & Components Data
 - ✅ Works offline (for console debugging)
 - ✅ No browser-based OAuth flow
 - ✅ Simpler for single-user setups
+- ✅ Full 57+ tools including real-time monitoring
 
 **Limitations:**
 - ❌ **Manual token creation required**
@@ -273,9 +356,12 @@ Variables & Components Data
 
 ## Figma Desktop Bridge Plugin
 
-### Recommended Connection Method (Local Mode)
+### Required for Both Local Mode and Cloud Mode
 
-The Desktop Bridge Plugin is the **recommended way** to connect Figma to the MCP server. It communicates via WebSocket (port 9223) — no special Figma launch flags needed, and it persists across Figma restarts.
+The Desktop Bridge Plugin is the bridge between Figma and the MCP server. It communicates via WebSocket — no special Figma launch flags needed, and it persists across Figma restarts.
+
+- **Local Mode:** Plugin connects directly to the local MCP server via WebSocket (ports 9223-9232)
+- **Cloud Mode:** Plugin connects to the Cloudflare relay via WebSocket after pairing with a 6-character code
 
 **Plugin Setup:**
 1. Open Figma Desktop (normal launch — no debug flags needed)
@@ -285,41 +371,58 @@ The Desktop Bridge Plugin is the **recommended way** to connect Figma to the MCP
 
 > **One-time import.** Once imported, the plugin stays in your Development plugins list.
 
-**What the plugin provides (Local Mode only):**
+**What the plugin provides:**
 
-| Feature | Without Plugin | With Plugin (Local Only) |
-|---------|----------------|--------------------------|
-| Variables API | Enterprise plan required | ✅ Free/Pro plans work |
-| Variable data | REST API (limited) | ✅ Full local variables |
-| Component descriptions | Often missing (API bug) | ✅ Always present |
-| Data freshness | Cache + API limits | ✅ Real-time from Figma |
-| Multi-mode support | Limited | ✅ All modes (Light/Dark/etc) |
-| Selection tracking | ❌ | ✅ Real-time via WebSocket |
-| Document change monitoring | ❌ | ✅ Real-time via WebSocket |
+| Feature | Without Plugin | With Plugin (Cloud Mode) | With Plugin (Local Mode) |
+|---------|----------------|--------------------------|--------------------------|
+| Variables API | Enterprise plan required | ✅ Free/Pro plans work | ✅ Free/Pro plans work |
+| Variable data | REST API (limited) | ✅ Full local variables | ✅ Full local variables |
+| Component descriptions | Often missing (API bug) | ✅ Always present | ✅ Always present |
+| Design creation (write) | ❌ | ✅ Via cloud relay | ✅ Via local WebSocket |
+| Data freshness | Cache + API limits | Per-request via relay | ✅ Real-time from Figma |
+| Selection tracking | ❌ | ❌ | ✅ Real-time via WebSocket |
+| Document change monitoring | ❌ | ❌ | ✅ Real-time via WebSocket |
 
-**Transport:** The MCP server communicates via WebSocket through the Desktop Bridge Plugin. The server automatically selects an available port in the range 9223–9232, supporting multiple simultaneous MCP instances. All 57+ tools work through the WebSocket transport.
+**Local Mode Transport:** The server automatically selects an available port in the range 9223–9232, supporting multiple simultaneous MCP instances. All 57+ tools work through the WebSocket transport.
 
-### Plugin Only Works in Local Mode
+**Cloud Mode Transport:** The plugin connects to the Cloudflare relay after pairing. Write operations are relayed from the cloud MCP server through the Durable Object to the plugin. 43 tools are available.
 
-Remote mode runs in Cloudflare Workers which cannot connect to `localhost` on your machine. The Desktop Bridge Plugin requires a local MCP server (NPX or Local Git setup).
+### Plugin Does NOT Work with Remote Read-Only Mode
+
+Remote read-only mode runs in Cloudflare Workers which cannot connect to `localhost` on your machine. The Desktop Bridge Plugin requires either a local MCP server (NPX or Local Git) or Cloud Mode pairing.
 
 ---
 
-## When to Switch Installation Methods
+## When to Switch Modes
 
-### Switch from Remote SSE → NPX/Local Git if:
+### Switch from Remote (read-only) → Cloud Mode if:
+- ❌ You need to create or modify designs from a web AI client
 - ❌ You need variables but don't have Enterprise plan
 - ❌ Component descriptions are missing in API responses
-- ❌ You're developing Figma plugins (need console debugging)
-- ❌ You need instant console log feedback
-- ❌ You need Desktop Bridge plugin features
 
-### Switch from NPX/Local Git → Remote SSE if:
+### Switch from Remote (read-only) → NPX/Local Git if:
+- ❌ You need real-time selection tracking or document change monitoring
+- ❌ You're developing Figma plugins (need console log streaming)
+- ❌ You need the full 57+ tool set
+- ❌ You need offline access
+
+### Switch from Cloud Mode → NPX/Local Git if:
+- ❌ You need real-time selection tracking or document changes
+- ❌ You need console log streaming
+- ❌ You need MCP Apps (Token Browser, Design System Dashboard)
+- ❌ Connection drops between AI turns are disruptive to your workflow
+
+### Switch from NPX/Local Git → Cloud Mode if:
+- ✅ You want to use web AI clients (Claude.ai, v0, Replit, Lovable)
+- ✅ You don't need real-time monitoring features
+- ✅ You can't or don't want to install Node.js
+
+### Switch from NPX/Local Git → Remote (read-only) if:
 - ✅ You got Enterprise plan (Variables API now available)
 - ✅ You're no longer developing plugins
 - ✅ You want zero-maintenance OAuth setup
 - ✅ You want per-user authentication
-- ✅ You don't need Desktop Bridge plugin
+- ✅ You only need read access
 
 ### Switch from NPX → Local Git if:
 - ✅ You want to modify source code
@@ -335,9 +438,9 @@ Remote mode runs in Cloudflare Workers which cannot connect to `localhost` on yo
 
 ## Cost Comparison
 
-All three installation methods are completely free:
+All setup methods are completely free:
 
-### Remote SSE (Free - Hosted by Project)
+### Remote / Cloud Mode (Free - Hosted by Project)
 - ✅ Free to use
 - ✅ Hosted on Cloudflare Workers
 - ✅ No infrastructure costs for users
@@ -362,7 +465,14 @@ All three installation methods are completely free:
 ### Remote Mode Common Issues
 - **"OAuth authentication failed"** → Try re-authenticating via auth_url
 - **"Browser connection timeout"** → Cold start (wait 30s, try again)
-- **"Variables API 403 error"** → Enterprise plan required (use Local Mode instead)
+- **"Variables API 403 error"** → Enterprise plan required (use Cloud Mode or Local Mode instead)
+
+### Cloud Mode Common Issues
+- **Pairing code expired** → Ask your AI to generate a new pairing code (codes expire after 5 minutes)
+- **Connection drops between AI turns** → Re-pair by asking your AI to reconnect and entering a fresh code in the plugin
+- **"Cloud Mode" toggle not visible** → Re-import the latest Desktop Bridge plugin manifest in Figma
+- **Plugin shows "Disconnected" in Cloud Mode** → Check your internet connection; the relay requires both the plugin and the cloud server to be online
+- **Write operations not working** → Verify the Desktop Bridge plugin is running in the file you want to modify
 
 ### Local Mode Common Issues
 - **"Failed to connect to Figma Desktop"** → Install the Desktop Bridge Plugin (Plugins → Development → Import from manifest) and run it in your file
@@ -375,10 +485,15 @@ All three installation methods are completely free:
 ## Summary
 
 **For most users: Start with NPX Setup** ⭐
-- All 57+ tools including design creation
+- All 57+ tools including design creation and real-time monitoring
 - Automatic updates with `@latest`
 - Desktop Bridge plugin support
 - Variables without Enterprise plan
+
+**Use Cloud Mode when:**
+- You use web AI clients (Claude.ai, v0, Replit, Lovable)
+- You need write access but can't install Node.js
+- You don't need real-time selection/document tracking
 
 **Use Local Git when:**
 - You're developing the MCP server
@@ -386,16 +501,18 @@ All three installation methods are completely free:
 - You need unreleased features
 - You're testing changes before contributing
 
-**Use Remote SSE when:**
+**Use Remote (read-only) when:**
 - You just want to explore/evaluate the tool
 - You only need read-only access to design data
 - You want zero-setup experience
 - You don't need design creation capabilities
 
-**Key Takeaway:** Remote SSE and Local modes have **different tool counts**:
-- **Remote Mode (SSE):** 22 tools — read-only operations
-- **Local Mode (NPX/Git):** 57+ tools — full read/write operations
+**Key Takeaway:** The three modes offer a clear capability progression:
+- **Remote (read-only):** 22 tools — view data, screenshots, design system extraction
+- **Cloud Mode:** 43 tools — adds full write access (create, edit, delete) via relay
+- **Local Mode (NPX/Git):** 57+ tools — adds real-time monitoring (selection, changes, console)
 
 The difference is not just authentication, but **fundamental capabilities**:
 - **Remote:** Cannot create, modify, or delete anything in Figma
-- **Local:** Full design creation, variable management, and component manipulation
+- **Cloud:** Full design creation and variable management via the Desktop Bridge relay
+- **Local:** Everything in Cloud, plus real-time selection tracking, document change monitoring, and console log streaming

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,23 +17,27 @@ Complete setup instructions for connecting Figma Console MCP to various AI clien
 |--------------|--------------|------|
 | **Create, modify, and develop with AI** | [NPX Setup](#-npx-setup-recommended) (Recommended) | ~10 min |
 | **Full capabilities with manual update control** | [Local Git Setup](#-local-git-setup-alternative) | ~15 min |
+| **Use AI from web clients** (Claude.ai, v0, Replit, Lovable) | [Cloud Mode](#-cloud-mode-web-ai-clients) | ~5 min |
 | **Set up with OpenAI Codex** (GUI config) | [Codex Setup](#-openai-codex) | ~5 min |
-| **Just explore my design data** (read-only) | [Remote SSE](#-remote-sse-read-only-exploration) | ~2 min |
+| **Just explore my design data** (read-only) | [Remote Mode](#-remote-mode-read-only-exploration) | ~2 min |
 
 ### ⚠️ Important: Capability Differences
 
-| Capability | NPX / Local Git | Remote SSE |
-|------------|-----------------|------------|
-| Read design data | ✅ | ✅ |
-| **Create components & frames** | ✅ | ❌ |
-| **Edit existing designs** | ✅ | ❌ |
-| **Manage design tokens/variables** | ✅ | ❌ |
-| Screenshot validation | ✅ | ✅ |
-| Desktop Bridge plugin | ✅ | ❌ |
-| Variables without Enterprise | ✅ | ❌ |
-| **Total tools available** | **56+** | **18** |
+| Capability | NPX / Local Git | Cloud Mode | Remote (read-only) |
+|------------|-----------------|------------|---------------------|
+| Read design data | ✅ | ✅ | ✅ |
+| **Create components & frames** | ✅ | ✅ | ❌ |
+| **Edit existing designs** | ✅ | ✅ | ❌ |
+| **Manage design tokens/variables** | ✅ | ✅ | ❌ |
+| Screenshot validation | ✅ | ✅ | ✅ |
+| Desktop Bridge plugin | ✅ | ✅ (required) | ❌ |
+| Variables without Enterprise | ✅ | ✅ | ❌ |
+| Real-time selection/change tracking | ✅ | ❌ | ❌ |
+| Console log streaming | ✅ | ❌ | ❌ |
+| Requires Node.js | Yes | No | No |
+| **Total tools available** | **57+** | **43** | **22** |
 
-> **Bottom line:** Remote SSE is **read-only** with ~34% of the tools. If you want AI to create, modify, or develop from your Figma designs, use NPX Setup.
+> **Bottom line:** Remote mode is **read-only** with 22 tools. Cloud Mode adds **write access** (43 tools) without Node.js. Local (NPX/Git) has **everything** (57+ tools) including real-time monitoring.
 
 ---
 
@@ -344,9 +348,9 @@ Then restart Claude Desktop.
 
 **What you get:** 22 read-only tools for viewing design data, taking screenshots, reading console logs, design-code parity checks, and full design system extraction via `figma_get_design_system_kit`.
 
-> ⚠️ **Limitation:** Remote mode **cannot create or modify designs**. It's read-only. For design creation, use [NPX Setup](#-npx-setup-recommended).
+> ⚠️ **Limitation:** Remote mode **cannot create or modify designs**. It's read-only. For write access from web AI clients, see [Cloud Mode](#-cloud-mode-web-ai-clients). For full capabilities, use [NPX Setup](#-npx-setup-recommended).
 
-Two remote endpoints are available — both provide the same 22 tools:
+Two remote endpoints are available — both provide the same 22 read-only tools:
 
 | Endpoint | Transport | Auth | Best For |
 |----------|-----------|------|----------|
@@ -412,9 +416,69 @@ The `/mcp` endpoint accepts your Figma Personal Access Token as a Bearer token �
 - ❌ Instantiate components
 - ❌ Use Desktop Bridge plugin
 
-### Upgrading to Full Capabilities
+### Upgrading to Write Access
 
-Ready for design creation? Follow the [NPX Setup](#-npx-setup-recommended) guide above.
+Want to create and modify designs from a web AI client? See [Cloud Mode](#-cloud-mode-web-ai-clients) — no Node.js required.
+
+Ready for full capabilities including real-time monitoring? Follow the [NPX Setup](#-npx-setup-recommended) guide above.
+
+---
+
+## ☁️ Cloud Mode (Web AI Clients)
+
+**Best for:** Claude.ai, v0, Replit, Lovable, and any MCP-capable web platform that needs to create and modify Figma designs.
+
+**What you get:** 43 tools — full write access (create frames, components, variables, edit designs) plus REST API reads. This is Remote Mode upgraded with the Cloud Write Relay.
+
+**What you don't get vs Local:** Real-time selection tracking, document change monitoring, and console log streaming (these require a local WebSocket connection).
+
+### Prerequisites
+
+- [ ] **Figma Desktop** with the Desktop Bridge plugin installed and running in your file
+- [ ] A web AI client connected to the remote MCP endpoint (`/mcp` with your Figma PAT as Bearer token)
+
+> No Node.js required. The relay runs entirely in Cloudflare Workers.
+
+### How to Connect (~2 min)
+
+1. **Tell your AI to connect to your Figma plugin** using natural language. For example:
+   - "Connect to my Figma plugin"
+   - "Pair with my design file"
+   - "I want to create designs in Figma"
+
+2. **Your AI generates a 6-character pairing code** (expires in 5 minutes)
+
+3. **In Figma Desktop:**
+   - Open the Desktop Bridge plugin (Plugins → Development → Figma Desktop Bridge)
+   - Toggle **"Cloud Mode"** in the plugin UI
+   - Enter the pairing code
+   - Click **Connect**
+
+4. **Done.** Your AI now has full write access to the open Figma file through the cloud relay.
+
+### What You Can Do (43 Tools)
+
+- ✅ Create frames, shapes, and components
+- ✅ Edit existing designs (resize, reposition, restyle)
+- ✅ Create and manage variables on any Figma plan (via Plugin API)
+- ✅ Instantiate components and set instance properties
+- ✅ Clone, delete, and rename nodes
+- ✅ Set fills, strokes, and text content
+- ✅ Read design data, take screenshots, extract design systems
+
+### What's Local-Only (Not Available in Cloud Mode)
+
+- ❌ Real-time selection tracking
+- ❌ Document change monitoring
+- ❌ Console log streaming
+- ❌ MCP Apps (Token Browser, Design System Dashboard)
+
+### Tips
+
+- The pairing code expires after **5 minutes** — generate a new one if it times out
+- If the connection drops between AI turns, ask your AI to reconnect and enter a fresh code
+- The Desktop Bridge plugin must stay running in your Figma file for the relay to work
+- Variables work on **any Figma plan** (Free, Pro, Organization) because the relay uses the Plugin API, not the Enterprise REST API
 
 ---
 
@@ -555,6 +619,9 @@ For reference, the Codex GUI fields map directly to the [NPX JSON configuration]
 | WebSocket unreachable from Docker host | Server bound to localhost | Set `FIGMA_WS_HOST=0.0.0.0` and expose port with `-p 9223:9223` |
 | Plugin shows "Disconnected" | MCP server not running | Start/restart your MCP client so the server starts |
 | NPX using old version | Cached package | Use `figma-console-mcp@latest` explicitly |
+| Cloud pairing code expired | Code is older than 5 minutes | Ask your AI to generate a new pairing code |
+| Cloud connection drops between turns | Relay session ended | Re-pair by asking your AI to reconnect, then enter the new code in the plugin |
+| Cloud Mode toggle not showing | Outdated Desktop Bridge plugin | Re-import the latest `figma-desktop-bridge/manifest.json` in Figma |
 
 ### Node.js Version Issues
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,7 +7,7 @@ description: "Complete API reference for all 57+ MCP tools, including parameters
 
 This guide provides detailed documentation for each tool, including when to use them and best practices.
 
-> **Note:** Local Mode (NPX/Git) provides **57+ tools** with full read/write capabilities. Remote Mode (SSE) provides **22 read-only tools** (including design-code parity and design system kit tools). Tools marked "Local" in the table below are not available in Remote Mode.
+> **Note:** Local Mode (NPX/Git) provides **57+ tools** with full read/write capabilities and real-time monitoring. Remote Mode provides **22 read-only tools** by default, or **43 tools** (including full write access) when paired with the Desktop Bridge plugin via Cloud Relay. Tools marked "Local" in the table below require Local Mode. Tools marked "Local / Cloud" work in both Local Mode and Cloud Mode (after pairing).
 
 ## Quick Reference
 
@@ -29,42 +29,43 @@ This guide provides detailed documentation for each tool, including when to use 
 | | `figma_get_file_data` | File structure with verbosity control | All |
 | | `figma_get_file_for_plugin` | File data optimized for plugins | All |
 | | `figma_get_design_system_kit` | **Full design system in one call** (tokens, components, styles, visual specs) | All |
-| | `figma_get_design_system_summary` | Overview of design system | Local |
-| | `figma_get_token_values` | Get variable values by mode | Local |
-| **✏️ Design Creation** | `figma_execute` | Run Figma Plugin API code | Local |
-| | `figma_arrange_component_set` | Organize variants with labels | Local |
-| | `figma_set_description` | Add component descriptions | Local |
-| **🧩 Components** | `figma_search_components` | Find components by name | Local |
-| | `figma_get_component_details` | Get component details | Local |
-| | `figma_instantiate_component` | Create component instance | Local |
-| | `figma_add_component_property` | Add component property | Local |
-| | `figma_edit_component_property` | Edit component property | Local |
-| | `figma_delete_component_property` | Remove component property | Local |
-| **🔧 Variables** | `figma_create_variable_collection` | Create collections with modes | Local |
-| | `figma_create_variable` | Create new variables | Local |
-| | `figma_update_variable` | Update variable values | Local |
-| | `figma_rename_variable` | Rename variables | Local |
-| | `figma_delete_variable` | Delete variables | Local |
-| | `figma_delete_variable_collection` | Delete collections | Local |
-| | `figma_add_mode` | Add modes to collections | Local |
-| | `figma_rename_mode` | Rename modes | Local |
-| | `figma_batch_create_variables` | Create up to 100 variables at once | Local |
-| | `figma_batch_update_variables` | Update up to 100 variables at once | Local |
-| | `figma_setup_design_tokens` | Create collection + modes + variables atomically | Local |
+| | `figma_get_design_system_summary` | Overview of design system | Local / Cloud |
+| | `figma_get_token_values` | Get variable values by mode | Local / Cloud |
+| **✏️ Design Creation** | `figma_execute` | Run Figma Plugin API code | Local / Cloud |
+| | `figma_arrange_component_set` | Organize variants with labels | Local / Cloud |
+| | `figma_set_description` | Add component descriptions | Local / Cloud |
+| **🧩 Components** | `figma_search_components` | Find components by name | Local / Cloud |
+| | `figma_get_component_details` | Get component details | Local / Cloud |
+| | `figma_instantiate_component` | Create component instance | Local / Cloud |
+| | `figma_add_component_property` | Add component property | Local / Cloud |
+| | `figma_edit_component_property` | Edit component property | Local / Cloud |
+| | `figma_delete_component_property` | Remove component property | Local / Cloud |
+| **🔧 Variables** | `figma_create_variable_collection` | Create collections with modes | Local / Cloud |
+| | `figma_create_variable` | Create new variables | Local / Cloud |
+| | `figma_update_variable` | Update variable values | Local / Cloud |
+| | `figma_rename_variable` | Rename variables | Local / Cloud |
+| | `figma_delete_variable` | Delete variables | Local / Cloud |
+| | `figma_delete_variable_collection` | Delete collections | Local / Cloud |
+| | `figma_add_mode` | Add modes to collections | Local / Cloud |
+| | `figma_rename_mode` | Rename modes | Local / Cloud |
+| | `figma_batch_create_variables` | Create up to 100 variables at once | Local / Cloud |
+| | `figma_batch_update_variables` | Update up to 100 variables at once | Local / Cloud |
+| | `figma_setup_design_tokens` | Create collection + modes + variables atomically | Local / Cloud |
 | **🔍 Design-Code Parity** | `figma_check_design_parity` | Compare Figma specs vs code implementation | All |
 | | `figma_generate_component_doc` | Generate component documentation from Figma + code | All |
 | **💬 Comments** | `figma_get_comments` | Get comments on a Figma file | All |
 | | `figma_post_comment` | Post a comment, optionally pinned to a node | All |
 | | `figma_delete_comment` | Delete a comment by ID | All |
-| **📐 Node Manipulation** | `figma_resize_node` | Resize a node | Local |
-| | `figma_move_node` | Move a node | Local |
-| | `figma_clone_node` | Clone a node | Local |
-| | `figma_delete_node` | Delete a node | Local |
-| | `figma_rename_node` | Rename a node | Local |
-| | `figma_set_text` | Set text content | Local |
-| | `figma_set_fills` | Set fill colors | Local |
-| | `figma_set_strokes` | Set stroke colors | Local |
-| | `figma_create_child` | Create child node | Local |
+| **📐 Node Manipulation** | `figma_resize_node` | Resize a node | Local / Cloud |
+| | `figma_move_node` | Move a node | Local / Cloud |
+| | `figma_clone_node` | Clone a node | Local / Cloud |
+| | `figma_delete_node` | Delete a node | Local / Cloud |
+| | `figma_rename_node` | Rename a node | Local / Cloud |
+| | `figma_set_text` | Set text content | Local / Cloud |
+| | `figma_set_fills` | Set fill colors | Local / Cloud |
+| | `figma_set_strokes` | Set stroke colors | Local / Cloud |
+| | `figma_create_child` | Create child node | Local / Cloud |
+| **☁️ Cloud Relay** | `figma_pair_plugin` | Generate pairing code for Desktop Bridge | Cloud |
 
 ---
 
@@ -570,9 +571,9 @@ figma_get_file_for_plugin({
 
 ---
 
-## ✏️ Design Creation Tools (Local Mode Only)
+## ✏️ Design Creation Tools
 
-> **⚠️ Requires Desktop Bridge Plugin**: These tools only work in Local Mode with the Desktop Bridge plugin running in Figma.
+> **⚠️ Requires Desktop Bridge Plugin**: These tools require the Desktop Bridge plugin running in Figma. In Local Mode, the plugin connects via WebSocket. In Cloud Mode, pair first using `figma_pair_plugin` to connect through the cloud relay.
 
 ### `figma_execute`
 
@@ -664,9 +665,9 @@ frame.paddingRight = 16;
 
 ---
 
-## 🔧 Variable Management Tools (Local Mode Only)
+## 🔧 Variable Management Tools
 
-> **⚠️ Requires Desktop Bridge Plugin**: These tools only work in Local Mode with the Desktop Bridge plugin running in Figma.
+> **⚠️ Requires Desktop Bridge Plugin**: These tools require the Desktop Bridge plugin running in Figma. In Local Mode, the plugin connects via WebSocket. In Cloud Mode, pair first using `figma_pair_plugin` to connect through the cloud relay.
 
 ### `figma_create_variable_collection`
 
@@ -1052,9 +1053,9 @@ figma_setup_design_tokens({
 
 ---
 
-## 🧩 Component Tools (Local Mode Only)
+## 🧩 Component Tools
 
-> **⚠️ Requires Desktop Bridge Plugin**: These tools only work in Local Mode with the Desktop Bridge plugin running in Figma.
+> **⚠️ Requires Desktop Bridge Plugin**: These tools require the Desktop Bridge plugin running in Figma. In Local Mode, the plugin connects via WebSocket. In Cloud Mode, pair first using `figma_pair_plugin` to connect through the cloud relay.
 
 ### `figma_search_components`
 
@@ -1215,7 +1216,7 @@ figma_set_description({
 
 ---
 
-## 🔧 Node Manipulation Tools (Local Mode Only)
+## 🔧 Node Manipulation Tools
 
 ### `figma_resize_node`
 
@@ -1350,7 +1351,7 @@ figma_create_child({
 
 ---
 
-## 🏷️ Component Property Tools (Local Mode Only)
+## 🏷️ Component Property Tools
 
 ### `figma_add_component_property`
 
@@ -1512,7 +1513,7 @@ figma_get_design_system_kit({
 
 ---
 
-## 📊 Design System Summary Tools (Local Mode Only)
+## 📊 Design System Summary Tools
 
 ### `figma_get_design_system_summary`
 
@@ -1604,11 +1605,16 @@ figma_get_token_values({
 
 ### Prerequisites Checklist
 
-Before using write tools, ensure:
-1. ✅ Running in **Local Mode** (not Remote SSE)
-2. ✅ Connected to Figma Desktop via **Desktop Bridge Plugin**
-3. ✅ **Desktop Bridge plugin** is running in your Figma file
-4. ✅ `figma_get_status` returns `setup.valid: true`
+Before using write tools, ensure one of the following:
+
+**Local Mode:**
+1. ✅ Running in **Local Mode** (NPX/Git)
+2. ✅ **Desktop Bridge plugin** is running in your Figma file
+3. ✅ `figma_get_status` returns `setup.valid: true`
+
+**Cloud Mode:**
+1. ✅ **Desktop Bridge plugin** is running in your Figma file with Cloud Mode enabled
+2. ✅ Paired via `figma_pair_plugin` (or natural language: "connect to my Figma plugin")
 
 ---
 
@@ -1855,6 +1861,37 @@ figma_delete_comment({
 **Returns:**
 - `success`: Boolean indicating deletion success
 - `deleted_comment_id`: The ID that was deleted
+
+---
+
+## ☁️ Cloud Relay
+
+### `figma_pair_plugin`
+
+Generate a pairing code to connect the Figma Desktop Bridge plugin to the cloud relay. This enables write operations from web-based AI clients.
+
+**Mode:** Cloud only (available on `/mcp` endpoint)
+
+**Parameters:** None
+
+**Returns:**
+- `code` — 6-character alphanumeric pairing code (uppercase, no ambiguous characters)
+- `expiresIn` — Expiry time (5 minutes)
+- Instructions for the user
+
+**Natural language triggers:**
+- "Connect to my Figma plugin"
+- "Pair with my design file"
+- "Set up the cloud connection"
+- "Link Figma to this chat"
+
+**How it works:**
+1. Generates a unique 6-character code stored in KV with 5-minute TTL
+2. User enters code in the Desktop Bridge plugin's Cloud Mode section
+3. Plugin connects via WebSocket to the cloud relay Durable Object
+4. All subsequent write tool calls route through the relay to the plugin
+
+**Important:** The pairing code expires after 5 minutes. If it expires before the plugin connects, generate a new one.
 
 ---
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -258,9 +258,9 @@ Then run your plugin in Figma Desktop, and say:
 
 ---
 
-## ✏️ Design Creation (Local Mode)
+## ✏️ Design Creation (Local Mode & Cloud Mode)
 
-These scenarios require Local Mode with the Desktop Bridge plugin installed. They enable AI-assisted design creation directly in Figma.
+These scenarios require the Desktop Bridge plugin. In Local Mode, the plugin connects via WebSocket. In Cloud Mode, say "connect to my Figma plugin" first to pair via the cloud relay — then all the same prompts work from web-based AI clients like Claude.ai, v0, Replit, and Lovable.
 
 ### Scenario 11: Create Component Variants with Variables
 
@@ -410,9 +410,9 @@ Use markdown formatting."
 
 ---
 
-### Scenario 17: Variable Mode Management
+### Scenario 17: Variable Mode Management (Local Mode & Cloud Mode)
 
-**Your situation:** You need to add a dark mode to your design system variables.
+**Your situation:** You need to add a dark mode to your design system variables. This works in both Local Mode and Cloud Mode (after pairing).
 
 **What to say:**
 
@@ -478,6 +478,95 @@ Each should have 3 sizes (24px, 32px, 40px) and use the same variable bindings a
 4. Continue iterating until you're satisfied
 
 This workflow leverages the screenshot feedback loop for precise design control.
+
+---
+
+## ☁️ Cloud Mode Workflows
+
+These scenarios are for web-based AI clients (Claude.ai, v0, Replit, Lovable) that connect to Figma through the cloud relay. No local installation required — just the Desktop Bridge plugin running in Figma.
+
+### Scenario: Connect Cloud AI to Figma (First Time)
+
+**Your situation:** You're using Claude.ai (or v0, Replit, Lovable) and want to create or modify designs in Figma.
+
+**What to say:**
+
+```
+"Connect to my Figma plugin so we can start designing"
+```
+
+or
+
+```
+"Pair with my Figma file"
+```
+
+**What happens:**
+1. AI generates a 6-character pairing code (valid for 5 minutes)
+2. You enter the code in the Desktop Bridge plugin's Cloud Mode section
+3. The plugin connects to the cloud relay — you're paired
+4. All write tools (43 total) are now available through the cloud
+
+**Follow-up prompts:**
+- "Create a card component with an image, title, and description"
+- "Update my primary color variable to #006699"
+- "Show me what components are in this file"
+
+---
+
+### Scenario: Design System Extraction for AI Code Generators (Cloud)
+
+**Your situation:** You're using v0, Replit, or Lovable and want your actual design tokens — not REST API snapshots that require an Enterprise plan.
+
+**What to say:**
+
+```
+"Connect to my Figma file and extract my design system variables"
+```
+
+**What happens:**
+1. AI generates a pairing code, you enter it in the plugin
+2. Plugin API extracts ALL variables on any Figma plan (Pro, Org, or Enterprise)
+3. AI receives full token data: colors, spacing, typography, with all mode values (Light/Dark/etc.)
+4. You can now generate code using your real design system
+
+**Why this matters:** The Figma REST API requires an Enterprise plan to access variables. Cloud Relay bypasses this limitation because the Desktop Bridge plugin uses the Plugin API, which works on all plans.
+
+---
+
+### Scenario: Update Design Tokens from Web Chat
+
+**Your situation:** You're in a meeting, using Claude.ai on a laptop, and want to update a brand color across your design system.
+
+**What to say:**
+
+```
+"Connect to Figma and change the primary brand color to #006699 across all modes"
+```
+
+**What happens:**
+1. AI generates pairing code, you enter it in the Desktop Bridge plugin
+2. AI reads your current variables to find the primary color
+3. Updates the value across Light, Dark, and any other modes
+4. Confirms the changes with the new values
+
+---
+
+### Scenario: Create Components from Web AI Client
+
+**Your situation:** You're using Claude.ai to prototype a new component and want it created directly in Figma.
+
+**What to say:**
+
+```
+"Connect to my Figma and create a notification toast with an icon, title text, and a dismiss button"
+```
+
+**What happens:**
+1. AI generates pairing code, you enter it in the plugin
+2. AI uses the plugin API to create a frame with auto-layout
+3. Adds child elements (icon placeholder, title text, dismiss button)
+4. Takes a screenshot to verify the result and show you what was created
 
 ---
 
@@ -604,6 +693,8 @@ This workflow leverages the screenshot feedback loop for precise design control.
 2. **Use filters:** "Show me only error logs from the last minute"
 3. **Be specific about formats:** "Export as Tailwind v4 syntax"
 4. **Request enrichment explicitly:** "Get variables with CSS exports and usage information"
+5. **Cloud Mode — connect first:** Start by saying "pair with my Figma plugin" or "connect to Figma" before asking for design changes
+6. **Use natural language:** You don't need to know tool names. Say "create a blue square" not "call figma_execute"
 
 ---
 

--- a/figma-desktop-bridge/README.md
+++ b/figma-desktop-bridge/README.md
@@ -1,20 +1,28 @@
 # Figma Desktop Bridge
 
-A Figma plugin that bridges the Variables API and Component descriptions to MCP (Model Context Protocol) clients without requiring an Enterprise plan.
+A Figma plugin that bridges the Variables API and Component descriptions to MCP (Model Context Protocol) clients without requiring an Enterprise plan. Supports both local MCP servers and cloud relay connections from web-based AI clients.
 
 ## Overview
 
-This plugin enables AI assistants like Claude Code and Claude Desktop to access your Figma variables AND component descriptions through the MCP protocol. It bypasses both Figma's plugin sandbox restrictions and the REST API's component description bug.
+This plugin enables AI assistants to access your Figma variables AND component descriptions through the MCP protocol. It serves two purposes:
+
+- **Local MCP bridge** — Connects to a local MCP server via WebSocket on localhost (Claude Code, Claude Desktop, Cursor)
+- **Cloud relay bridge** — Connects to a cloud relay via WebSocket over TLS, enabling web-based AI clients (Claude.ai, v0, Replit, Lovable) to send write commands to Figma
+
+Both modes bypass Figma's plugin sandbox restrictions and the REST API's component description bug.
 
 ## Architecture
 
-The plugin communicates with the MCP server via WebSocket:
+The plugin communicates with MCP servers via WebSocket through two paths:
 
 ```
-MCP Server ←WebSocket (ports 9223–9232)→ Plugin UI ←postMessage→ Plugin Worker → Figma API
+LOCAL:  MCP Server ←WebSocket (ports 9223–9232)→ Plugin UI ←postMessage→ Plugin Worker → Figma API
+CLOUD:  Cloud MCP Server → Relay DO ←WebSocket (wss://)→ Plugin UI ←postMessage→ Plugin Worker → Figma API
 ```
 
-As of v1.10.0, the server supports multi-instance operation — if port 9223 is already in use, it automatically falls back through ports 9224–9232. The plugin scans all ports and connects to every active server.
+For local mode, the server supports multi-instance operation — if port 9223 is already in use, it automatically falls back through ports 9224–9232. The plugin scans all ports and connects to every active server.
+
+For cloud mode, the plugin connects to a Cloudflare Durable Object relay via a one-time pairing code. Web-based AI clients send write commands through the relay to the plugin.
 
 **Key Features:**
 - ✅ No Enterprise plan required for variables
@@ -28,6 +36,8 @@ As of v1.10.0, the server supports multi-instance operation — if port 9223 is 
 - ✅ WebSocket transport — no debug flags needed
 - ✅ Auto-reconnect on connection loss
 - ✅ Multi-instance: connects to all active MCP servers simultaneously (v1.10.0)
+- ✅ Cloud Mode: pair with web-based AI clients (Claude.ai, v0, Replit, Lovable)
+- ✅ Full write access from any MCP-capable web platform
 
 ## Installation
 
@@ -91,6 +101,29 @@ figma_get_component({
 ```
 
 **Important:** Keep the plugin running while querying. Variables are pre-loaded, but component data is fetched on-demand when requested.
+
+## Cloud Mode
+
+Cloud Mode lets web-based AI clients (Claude.ai, v0, Replit, Lovable) send write commands to your Figma file through a cloud relay. This enables the full suite of design creation and variable management tools from any MCP-capable web platform — no local Node.js required.
+
+### How to Connect
+
+1. **Start pairing from the AI client.** The AI client calls `figma_pair_plugin`, which generates a 6-character pairing code (valid for 5 minutes).
+2. **Open the Desktop Bridge plugin** in Figma Desktop.
+3. **Expand Cloud Mode.** Click the "Cloud Mode" toggle (chevron) below the status bar.
+4. **Enter the pairing code** in the text input and click **Connect**.
+5. The plugin establishes a WebSocket connection to the cloud relay. The status indicator changes to "Connected to cloud relay."
+
+### Disconnecting
+
+Click the **Disconnect** button in the Cloud Mode section, or close the plugin. The cloud relay session is terminated immediately.
+
+### Notes
+
+- **Both local and cloud connections can be active simultaneously.** Local MCP servers continue to work while Cloud Mode is connected.
+- **Pairing codes are single-use.** Each code can only be used once. If connection fails, generate a new code from the AI client.
+- **Codes expire in 5 minutes.** If the code has expired, ask the AI client to generate a fresh one.
+- **One plugin per relay session.** Each pairing code creates a dedicated relay instance scoped to that session.
 
 ## How It Works
 
@@ -173,6 +206,16 @@ figma_get_component({
 - Cache TTL is 5 minutes for variables - use `refreshCache: true` for immediate updates
 - Ensure you're in the correct file (plugin reads current file's data)
 
+### Cloud Mode shows "Connection failed"
+- The pairing code may have expired (codes are valid for 5 minutes). Generate a new one from the AI client.
+- Verify the code was entered correctly (6 characters, case-sensitive).
+
+### Cloud Mode disconnect button doesn't work
+- Close and reopen the Cloud Mode section, then try again.
+
+### Cloud connection drops between AI turns
+- Re-pair by generating a new pairing code from the AI client. The relay uses hibernation-safe patterns, but extended idle periods may cause reconnection. If it persists, generate a fresh code.
+
 ## Multi-Instance Support (v1.10.0)
 
 The Desktop Bridge plugin supports connecting to **multiple MCP server instances** simultaneously. This is useful when:
@@ -240,11 +283,20 @@ View logs: **Plugins → Development → Open Console** (Cmd+Option+I on Mac)
 
 ## Security
 
+**Local Mode:**
 - Plugin network access limited to `localhost` only (for WebSocket bridge)
 - Data never leaves the local machine
+- WebSocket bridge is local-only and unauthenticated — it relies on `localhost` binding for security. Multiple clients may be connected concurrently (one per Figma file). Do not expose the WebSocket port outside `localhost` (e.g., via port forwarding) on untrusted machines
+
+**Cloud Mode:**
+- Cloud relay connection uses TLS (`wss://`) for all traffic
+- Pairing codes are single-use and expire in 5 minutes — no unauthenticated access is possible
+- Each relay Durable Object is scoped per session (one plugin per relay instance)
+- The relay passes commands through without storing design data persistently
+
+**Both Modes:**
 - Uses standard Figma Plugin API (no unofficial APIs)
 - Component requests are scoped to current file only
-- WebSocket bridge is local-only and unauthenticated — it relies on `localhost` binding for security. Multiple clients may be connected concurrently (one per Figma file). Do not expose the WebSocket port outside `localhost` (e.g., via port forwarding) on untrusted machines
 
 ## Why Desktop Bridge for Components?
 

--- a/figma-desktop-bridge/code.js
+++ b/figma-desktop-bridge/code.js
@@ -7,7 +7,7 @@
 console.log('🌉 [Desktop Bridge] Plugin loaded and ready');
 
 // Show minimal UI - compact status indicator
-figma.showUI(__html__, { width: 120, height: 36, visible: true, themeColors: true });
+figma.showUI(__html__, { width: 140, height: 50, visible: true, themeColors: true });
 
 // ============================================================================
 // CONSOLE CAPTURE — Intercept console.* in the QuickJS sandbox and forward
@@ -1996,6 +1996,21 @@ figma.ui.onmessage = async (msg) => {
   }
 
   // ============================================================================
+  // RESIZE_UI - Dynamically resize the plugin window (e.g., Cloud Mode toggle)
+  // ============================================================================
+  else if (msg.type === 'RESIZE_UI') {
+    figma.ui.resize(msg.width || 120, msg.height || 36);
+  }
+
+  // ============================================================================
+  // STORE_CLOUD_CONFIG - Persist cloud pairing config in clientStorage
+  // ============================================================================
+  else if (msg.type === 'STORE_CLOUD_CONFIG') {
+    figma.clientStorage.setAsync('cloudConfig', { code: msg.code, timestamp: Date.now() })
+      .catch(function() { /* non-critical */ });
+  }
+
+  // ============================================================================
   // RELOAD_UI - Reload the plugin UI iframe (re-establishes WebSocket connection)
   // Uses figma.showUI(__html__) to reload without restarting code.js
   // ============================================================================
@@ -2009,7 +2024,7 @@ figma.ui.onmessage = async (msg) => {
       });
       // Short delay to let the response message be sent before reload
       setTimeout(function() {
-        figma.showUI(__html__, { width: 120, height: 36, visible: true, themeColors: true });
+        figma.showUI(__html__, { width: 140, height: 50, visible: true, themeColors: true });
       }, 100);
     } catch (error) {
       var errorMsg = error && error.message ? error.message : String(error);

--- a/figma-desktop-bridge/manifest.json
+++ b/figma-desktop-bridge/manifest.json
@@ -32,9 +32,11 @@
       "ws://localhost:9229",
       "ws://localhost:9230",
       "ws://localhost:9231",
-      "ws://localhost:9232"
+      "ws://localhost:9232",
+      "wss://figma-console-mcp.southleft.com",
+      "https://figma-console-mcp.southleft.com"
     ],
-    "reasoning": "Connects to local MCP server via WebSocket. Supports port range 9223-9232 for multi-instance operation (e.g., multiple Claude Desktop tabs or CLI tools).",
+    "reasoning": "Connects to local MCP server via WebSocket (port range 9223-9232 for multi-instance), and optionally to the cloud relay for remote write access.",
     "devAllowedDomains": [
       "http://localhost",
       "http://localhost:9223",
@@ -57,7 +59,9 @@
       "ws://localhost:9229",
       "ws://localhost:9230",
       "ws://localhost:9231",
-      "ws://localhost:9232"
+      "ws://localhost:9232",
+      "wss://figma-console-mcp.southleft.com",
+      "https://figma-console-mcp.southleft.com"
     ]
   }
 }

--- a/figma-desktop-bridge/ui.html
+++ b/figma-desktop-bridge/ui.html
@@ -79,6 +79,98 @@
       margin-left: 4px;
     }
 
+    /* Cloud Mode toggle */
+    .cloud-section {
+      display: none;
+      width: 100%;
+    }
+
+    .cloud-section.visible {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-top: 6px;
+    }
+
+    .cloud-toggle {
+      display: flex;
+      align-items: center;
+      gap: 3px;
+      cursor: pointer;
+      font-size: 10px;
+      color: var(--figma-color-text-secondary, rgba(255, 255, 255, 0.5));
+      user-select: none;
+      margin-top: 2px;
+    }
+
+    .cloud-toggle:hover {
+      color: var(--figma-color-text, rgba(255, 255, 255, 0.9));
+    }
+
+    .cloud-toggle .chevron {
+      display: inline-block;
+      font-size: 8px;
+      transition: transform 0.15s ease;
+    }
+
+    .cloud-toggle.expanded .chevron {
+      transform: rotate(90deg);
+    }
+
+    .cloud-input-row input {
+      width: 100%;
+      background: var(--figma-color-bg, #2c2c2c);
+      border: 1px solid var(--figma-color-border, #4a4a4a);
+      border-radius: 3px;
+      color: var(--figma-color-text, rgba(255, 255, 255, 0.9));
+      font-family: monospace;
+      font-size: 12px;
+      padding: 4px 6px;
+      text-transform: uppercase;
+      letter-spacing: 3px;
+      text-align: center;
+      box-sizing: border-box;
+    }
+
+    .cloud-input-row input::placeholder {
+      text-transform: none;
+      letter-spacing: normal;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 10px;
+      color: var(--figma-color-text-secondary, rgba(255, 255, 255, 0.3));
+    }
+
+    .cloud-input-row button {
+      width: 100%;
+      background: var(--figma-color-bg-brand, #0d99ff);
+      color: #fff;
+      border: none;
+      border-radius: 3px;
+      font-size: 10px;
+      font-weight: 500;
+      padding: 5px 8px;
+      cursor: pointer;
+    }
+
+    .cloud-input-row button:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+
+    .cloud-status {
+      font-size: 9px;
+      color: var(--figma-color-text-secondary, rgba(255, 255, 255, 0.5));
+      text-align: center;
+    }
+
+    .cloud-status.connected {
+      color: #18a957;
+    }
+
+    .cloud-status.error {
+      color: #f24822;
+    }
+
     /* Light theme support */
     @media (prefers-color-scheme: light) {
       body {
@@ -99,11 +191,27 @@
   </style>
 </head>
 <body>
-  <div class="bridge-status" id="status-container">
-    <div class="status-indicator loading" id="status-dot"></div>
-    <div class="status-text">
-      <span class="label">MCP</span>
-      <span class="state" id="status-state">connecting</span>
+  <div style="display: flex; flex-direction: column; align-items: center; width: 100%;">
+    <div class="bridge-status" id="status-container">
+      <div class="status-indicator loading" id="status-dot"></div>
+      <div class="status-text">
+        <span class="label">MCP</span>
+        <span class="state" id="status-state">connecting</span>
+      </div>
+    </div>
+
+    <div class="cloud-toggle" id="cloud-toggle" onclick="toggleCloudSection()">
+      <span class="chevron">▶</span> Cloud Mode
+    </div>
+
+    <div class="cloud-section" id="cloud-section">
+      <div class="cloud-input-row">
+        <input type="text" id="cloud-code" maxlength="6" placeholder="Pairing code" autocomplete="off" />
+      </div>
+      <div class="cloud-input-row">
+        <button id="cloud-btn" onclick="cloudConnect()">Connect</button>
+      </div>
+      <div class="cloud-status" id="cloud-status"></div>
     </div>
   </div>
 
@@ -774,11 +882,134 @@
         }
       };
 
+      // Expose functions for Cloud Mode to add connections to the same pool
+      window.__wsAddCloudConnection = function(cloudWs, label, onDisconnect) {
+        activeConnections.push({ port: label, ws: cloudWs });
+        updateCompatState();
+        attachWsHandlers(cloudWs, label);
+        // Chain cloud disconnect callback after attachWsHandlers' onclose
+        if (onDisconnect) {
+          var origOnClose = cloudWs.onclose;
+          cloudWs.onclose = function(event) {
+            if (origOnClose) origOnClose.call(cloudWs, event);
+            onDisconnect();
+          };
+        }
+        initializeConnection(cloudWs, label);
+      };
+
+      window.__wsGetActiveConnections = function() { return activeConnections; };
+
       // Single scan on load — no periodic rescanning to avoid console spam.
       // If no server found, retries up to MAX_INITIAL_SCANS times then stops.
       // On disconnect, retries the specific port up to 5 times then stops.
       wsScanAndConnect();
     })();
+
+    // ============================================================================
+    // CLOUD MODE — Connect to remote relay via pairing code
+    // ============================================================================
+    var cloudWs = null;
+    var CLOUD_RELAY_HOST = 'wss://figma-console-mcp.southleft.com';
+
+    function toggleCloudSection() {
+      var section = document.getElementById('cloud-section');
+      var toggle = document.getElementById('cloud-toggle');
+      var isExpanding = !section.classList.contains('visible');
+      section.classList.toggle('visible');
+      toggle.classList.toggle('expanded');
+
+      // Resize plugin window to fit content
+      var height = isExpanding ? 130 : 50;
+      parent.postMessage({ pluginMessage: { type: 'RESIZE_UI', width: 140, height: height } }, '*');
+    }
+
+    function resetCloudUI() {
+      var statusEl = document.getElementById('cloud-status');
+      var btn = document.getElementById('cloud-btn');
+      if (statusEl) {
+        statusEl.textContent = 'Disconnected';
+        statusEl.className = 'cloud-status';
+      }
+      if (btn) {
+        btn.disabled = false;
+        btn.textContent = 'Connect';
+        btn.onclick = cloudConnect;
+      }
+      cloudWs = null;
+    }
+
+    function cloudConnect() {
+      var codeInput = document.getElementById('cloud-code');
+      var btn = document.getElementById('cloud-btn');
+      var statusEl = document.getElementById('cloud-status');
+      var code = (codeInput.value || '').trim().toUpperCase();
+
+      if (!code || code.length < 4) {
+        statusEl.textContent = 'Enter pairing code';
+        statusEl.className = 'cloud-status error';
+        return;
+      }
+
+      btn.disabled = true;
+      statusEl.textContent = 'Connecting...';
+      statusEl.className = 'cloud-status';
+
+      // Close existing cloud connection if any
+      if (cloudWs && cloudWs.readyState <= 1) {
+        cloudWs.close();
+      }
+
+      try {
+        cloudWs = new WebSocket(CLOUD_RELAY_HOST + '/ws/pair?code=' + code);
+
+        cloudWs.onopen = function() {
+          statusEl.textContent = 'Connected to cloud relay';
+          statusEl.className = 'cloud-status connected';
+          btn.disabled = false;
+          btn.textContent = 'Disconnect';
+          btn.onclick = cloudDisconnect;
+
+          // Add to the shared connection pool (uses same handlers as localhost).
+          // Pass resetCloudUI as disconnect callback — attachWsHandlers overwrites
+          // onclose, so this callback ensures cloud UI resets on server-initiated close.
+          if (window.__wsAddCloudConnection) {
+            window.__wsAddCloudConnection(cloudWs, 'cloud', resetCloudUI);
+          }
+
+          // Persist cloud config via code.js clientStorage
+          parent.postMessage({ pluginMessage: {
+            type: 'STORE_CLOUD_CONFIG',
+            code: code
+          }}, '*');
+        };
+
+        cloudWs.onerror = function() {
+          statusEl.textContent = 'Connection failed — check code';
+          statusEl.className = 'cloud-status error';
+          btn.disabled = false;
+        };
+
+        // Note: onclose here handles pre-connection close (e.g., bad code).
+        // After onopen, attachWsHandlers overwrites this — resetCloudUI callback
+        // handles post-connection close instead.
+        cloudWs.onclose = function(event) {
+          resetCloudUI();
+        };
+      } catch (e) {
+        statusEl.textContent = 'Failed: ' + e.message;
+        statusEl.className = 'cloud-status error';
+        btn.disabled = false;
+      }
+    }
+
+    function cloudDisconnect() {
+      if (cloudWs) {
+        cloudWs.close();
+      }
+      // Reset UI immediately — don't rely on onclose (may be overwritten)
+      resetCloudUI();
+    }
 
     // ============================================================================
     // MESSAGE HANDLER - Process responses from plugin worker

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -20,6 +20,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^cloudflare:workers$': '<rootDir>/tests/__mocks__/cloudflare-workers.js',
   },
   // Required: WebSocket event listeners in tests can keep Node alive after tests complete
   forceExit: true,

--- a/src/browser-manager.ts
+++ b/src/browser-manager.ts
@@ -16,11 +16,13 @@ const logger = createChildLogger({ component: 'browser-manager' });
 export interface Env {
 	BROWSER: Fetcher;
 	MCP_OBJECT: DurableObjectNamespace;
+	PLUGIN_RELAY: DurableObjectNamespace; // Durable Object for cloud write relay (plugin ↔ cloud bridge)
 	OAUTH_TOKENS: KVNamespace; // KV for OAuth tokens (accessible across Durable Objects)
 	OAUTH_STATE: KVNamespace; // KV for OAuth state CSRF tokens (short-lived, 10 minute TTL)
 	FIGMA_ACCESS_TOKEN?: string; // Optional Figma API token for data extraction (deprecated, use OAuth)
 	FIGMA_OAUTH_CLIENT_ID?: string; // OAuth client ID for user authentication
 	FIGMA_OAUTH_CLIENT_SECRET?: string; // OAuth client secret for token exchange
+	CANONICAL_ORIGIN?: string; // Canonical origin for OAuth redirect URIs (e.g., https://figma-console-mcp.southleft.com)
 }
 
 /**

--- a/src/core/cloud-websocket-connector.ts
+++ b/src/core/cloud-websocket-connector.ts
@@ -1,0 +1,302 @@
+/**
+ * Cloud WebSocket Connector
+ *
+ * Implements IFigmaConnector by routing commands through the PluginRelayDO
+ * Durable Object. Each method maps to a command sent via fetch() RPC to
+ * the relay, which forwards it to the Figma Desktop Bridge plugin over
+ * WebSocket.
+ *
+ * Structurally mirrors WebSocketConnector — same methods, different transport.
+ */
+
+import type { IFigmaConnector } from './figma-connector.js';
+
+interface RelayStub {
+	fetch(input: string | Request, init?: RequestInit): Promise<Response>;
+}
+
+export class CloudWebSocketConnector implements IFigmaConnector {
+	private relayStub: RelayStub;
+
+	constructor(relayStub: RelayStub) {
+		this.relayStub = relayStub;
+	}
+
+	async initialize(): Promise<void> {
+		const res = await this.relayStub.fetch('https://relay/relay/status');
+		const status = await res.json() as { connected: boolean };
+		if (!status.connected) {
+			throw new Error(
+				'No plugin connected to cloud relay. User must pair the Desktop Bridge plugin first (use figma_pair_plugin tool).'
+			);
+		}
+	}
+
+	getTransportType(): 'cdp' | 'websocket' {
+		return 'websocket';
+	}
+
+	// ============================================================================
+	// Core execution
+	// ============================================================================
+
+	async executeInPluginContext<T = any>(code: string): Promise<T> {
+		return this.sendCommand('EXECUTE_CODE', { code, timeout: 5000 }, 7000);
+	}
+
+	async getVariablesFromPluginUI(fileKey?: string): Promise<any> {
+		return this.sendCommand('GET_VARIABLES_DATA', {}, 10000);
+	}
+
+	async getVariables(fileKey?: string): Promise<any> {
+		const code = `
+      (async () => {
+        try {
+          if (typeof figma === 'undefined') {
+            throw new Error('Figma API not available in this context');
+          }
+          const variables = await figma.variables.getLocalVariablesAsync();
+          const collections = await figma.variables.getLocalVariableCollectionsAsync();
+          return {
+            success: true,
+            timestamp: Date.now(),
+            fileMetadata: { fileName: figma.root.name, fileKey: figma.fileKey || null },
+            variables: variables.map(function(v) { return { id: v.id, name: v.name, key: v.key, resolvedType: v.resolvedType, valuesByMode: v.valuesByMode, variableCollectionId: v.variableCollectionId, scopes: v.scopes, description: v.description, hiddenFromPublishing: v.hiddenFromPublishing }; }),
+            variableCollections: collections.map(function(c) { return { id: c.id, name: c.name, key: c.key, modes: c.modes, defaultModeId: c.defaultModeId, variableIds: c.variableIds }; })
+          };
+        } catch (error) {
+          return { success: false, error: error.message };
+        }
+      })()
+    `;
+		return this.sendCommand('EXECUTE_CODE', { code, timeout: 30000 }, 32000);
+	}
+
+	async executeCodeViaUI(code: string, timeoutMs = 5000): Promise<any> {
+		return this.sendCommand('EXECUTE_CODE', { code, timeout: timeoutMs }, timeoutMs + 2000);
+	}
+
+	// ============================================================================
+	// Variable operations
+	// ============================================================================
+
+	async updateVariable(variableId: string, modeId: string, value: any): Promise<any> {
+		return this.sendCommand('UPDATE_VARIABLE', { variableId, modeId, value });
+	}
+
+	async createVariable(
+		name: string,
+		collectionId: string,
+		resolvedType: string,
+		options?: any
+	): Promise<any> {
+		const params: any = { name, collectionId, resolvedType };
+		if (options) {
+			if (options.valuesByMode) params.valuesByMode = options.valuesByMode;
+			if (options.description) params.description = options.description;
+			if (options.scopes) params.scopes = options.scopes;
+		}
+		return this.sendCommand('CREATE_VARIABLE', params);
+	}
+
+	async deleteVariable(variableId: string): Promise<any> {
+		return this.sendCommand('DELETE_VARIABLE', { variableId });
+	}
+
+	async refreshVariables(): Promise<any> {
+		return this.sendCommand('REFRESH_VARIABLES', {}, 300000);
+	}
+
+	async renameVariable(variableId: string, newName: string): Promise<any> {
+		const result = await this.sendCommand('RENAME_VARIABLE', { variableId, newName });
+		if (!result.oldName && result.variable?.oldName) result.oldName = result.variable.oldName;
+		return result;
+	}
+
+	async setVariableDescription(variableId: string, description: string): Promise<any> {
+		return this.sendCommand('SET_VARIABLE_DESCRIPTION', { variableId, description });
+	}
+
+	// ============================================================================
+	// Mode operations
+	// ============================================================================
+
+	async addMode(collectionId: string, modeName: string): Promise<any> {
+		return this.sendCommand('ADD_MODE', { collectionId, modeName });
+	}
+
+	async renameMode(collectionId: string, modeId: string, newName: string): Promise<any> {
+		const result = await this.sendCommand('RENAME_MODE', { collectionId, modeId, newName });
+		if (!result.oldName && result.collection?.oldName) result.oldName = result.collection.oldName;
+		return result;
+	}
+
+	// ============================================================================
+	// Collection operations
+	// ============================================================================
+
+	async createVariableCollection(name: string, options?: any): Promise<any> {
+		const params: any = { name };
+		if (options) {
+			if (options.initialModeName) params.initialModeName = options.initialModeName;
+			if (options.additionalModes) params.additionalModes = options.additionalModes;
+		}
+		return this.sendCommand('CREATE_VARIABLE_COLLECTION', params);
+	}
+
+	async deleteVariableCollection(collectionId: string): Promise<any> {
+		return this.sendCommand('DELETE_VARIABLE_COLLECTION', { collectionId });
+	}
+
+	// ============================================================================
+	// Component operations
+	// ============================================================================
+
+	async getComponentFromPluginUI(nodeId: string): Promise<any> {
+		return this.sendCommand('GET_COMPONENT', { nodeId }, 10000);
+	}
+
+	async getLocalComponents(): Promise<any> {
+		return this.sendCommand('GET_LOCAL_COMPONENTS', {}, 300000);
+	}
+
+	async setNodeDescription(nodeId: string, description: string, descriptionMarkdown?: string): Promise<any> {
+		return this.sendCommand('SET_NODE_DESCRIPTION', { nodeId, description, descriptionMarkdown });
+	}
+
+	async addComponentProperty(
+		nodeId: string,
+		propertyName: string,
+		type: string,
+		defaultValue: any,
+		options?: any
+	): Promise<any> {
+		const params: any = { nodeId, propertyName, propertyType: type, defaultValue };
+		if (options?.preferredValues) params.preferredValues = options.preferredValues;
+		return this.sendCommand('ADD_COMPONENT_PROPERTY', params);
+	}
+
+	async editComponentProperty(nodeId: string, propertyName: string, newValue: any): Promise<any> {
+		return this.sendCommand('EDIT_COMPONENT_PROPERTY', { nodeId, propertyName, newValue });
+	}
+
+	async deleteComponentProperty(nodeId: string, propertyName: string): Promise<any> {
+		return this.sendCommand('DELETE_COMPONENT_PROPERTY', { nodeId, propertyName });
+	}
+
+	async instantiateComponent(componentKey: string, options?: any): Promise<any> {
+		const params: any = { componentKey };
+		if (options) {
+			if (options.nodeId) params.nodeId = options.nodeId;
+			if (options.position) params.position = options.position;
+			if (options.size) params.size = options.size;
+			if (options.overrides) params.overrides = options.overrides;
+			if (options.variant) params.variant = options.variant;
+			if (options.parentId) params.parentId = options.parentId;
+		}
+		return this.sendCommand('INSTANTIATE_COMPONENT', params);
+	}
+
+	// ============================================================================
+	// Node manipulation
+	// ============================================================================
+
+	async resizeNode(nodeId: string, width: number, height: number, withConstraints = true): Promise<any> {
+		return this.sendCommand('RESIZE_NODE', { nodeId, width, height, withConstraints });
+	}
+
+	async moveNode(nodeId: string, x: number, y: number): Promise<any> {
+		return this.sendCommand('MOVE_NODE', { nodeId, x, y });
+	}
+
+	async setNodeFills(nodeId: string, fills: any[]): Promise<any> {
+		return this.sendCommand('SET_NODE_FILLS', { nodeId, fills });
+	}
+
+	async setNodeStrokes(nodeId: string, strokes: any[], strokeWeight?: number): Promise<any> {
+		const params: any = { nodeId, strokes };
+		if (strokeWeight !== undefined) params.strokeWeight = strokeWeight;
+		return this.sendCommand('SET_NODE_STROKES', params);
+	}
+
+	async setNodeOpacity(nodeId: string, opacity: number): Promise<any> {
+		return this.sendCommand('SET_NODE_OPACITY', { nodeId, opacity });
+	}
+
+	async setNodeCornerRadius(nodeId: string, radius: number): Promise<any> {
+		return this.sendCommand('SET_NODE_CORNER_RADIUS', { nodeId, radius });
+	}
+
+	async cloneNode(nodeId: string): Promise<any> {
+		return this.sendCommand('CLONE_NODE', { nodeId });
+	}
+
+	async deleteNode(nodeId: string): Promise<any> {
+		return this.sendCommand('DELETE_NODE', { nodeId });
+	}
+
+	async renameNode(nodeId: string, newName: string): Promise<any> {
+		return this.sendCommand('RENAME_NODE', { nodeId, newName });
+	}
+
+	async setTextContent(nodeId: string, characters: string, options?: any): Promise<any> {
+		const params: any = { nodeId, text: characters };
+		if (options) {
+			if (options.fontSize) params.fontSize = options.fontSize;
+			if (options.fontWeight) params.fontWeight = options.fontWeight;
+			if (options.fontFamily) params.fontFamily = options.fontFamily;
+		}
+		return this.sendCommand('SET_TEXT_CONTENT', params);
+	}
+
+	async createChildNode(parentId: string, nodeType: string, properties?: any): Promise<any> {
+		return this.sendCommand('CREATE_CHILD_NODE', { parentId, nodeType, properties: properties || {} });
+	}
+
+	// ============================================================================
+	// Screenshot & instance properties
+	// ============================================================================
+
+	async captureScreenshot(nodeId: string, options?: any): Promise<any> {
+		const params: any = { nodeId };
+		if (options?.format) params.format = options.format;
+		if (options?.scale) params.scale = options.scale;
+		return this.sendCommand('CAPTURE_SCREENSHOT', params, 30000);
+	}
+
+	async setInstanceProperties(nodeId: string, properties: any): Promise<any> {
+		return this.sendCommand('SET_INSTANCE_PROPERTIES', { nodeId, properties });
+	}
+
+	// ============================================================================
+	// Cache management (no-op for cloud relay)
+	// ============================================================================
+
+	clearFrameCache(): void {
+		// No frame cache in cloud relay mode
+	}
+
+	// ============================================================================
+	// Transport — fetch-based RPC to the relay DO
+	// ============================================================================
+
+	private async sendCommand(
+		method: string,
+		params: Record<string, any> = {},
+		timeoutMs = 15000,
+	): Promise<any> {
+		const res = await this.relayStub.fetch('https://relay/relay/command', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ method, params, timeoutMs }),
+		});
+
+		const data = await res.json() as { result?: any; error?: string };
+
+		if (data.error) {
+			throw new Error(data.error);
+		}
+
+		return data.result;
+	}
+}

--- a/src/core/cloud-websocket-relay.ts
+++ b/src/core/cloud-websocket-relay.ts
@@ -1,0 +1,255 @@
+/**
+ * Cloud WebSocket Relay — Durable Object
+ *
+ * Bridges the Figma Desktop Bridge plugin to the cloud MCP server.
+ * The plugin connects via WebSocket (hibernation-aware); the MCP DO
+ * sends commands via fetch() RPC and receives responses.
+ *
+ * IMPORTANT: Uses hibernation-safe patterns throughout:
+ *   - WebSocket retrieved via this.ctx.getWebSockets() (not class property)
+ *   - File info persisted in DO storage (not in-memory)
+ *   - Pending requests kept in-memory (safe: fetch keeps DO alive)
+ *
+ * Routes:
+ *   /ws/connect   — WebSocket upgrade from plugin (paired via code)
+ *   /relay/command — RPC from MCP DO → plugin (holds response open)
+ *   /relay/status  — Connection & file info query
+ */
+
+import { DurableObject } from 'cloudflare:workers';
+
+export interface RelayFileInfo {
+	fileName: string;
+	fileKey: string | null;
+	currentPage?: string;
+	currentPageId?: string;
+	connectedAt: number;
+}
+
+interface PendingRelay {
+	resolve: (value: Response) => void;
+	reject: (reason: Error) => void;
+	timeoutId: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Generate a 6-character alphanumeric pairing code (uppercase).
+ */
+export function generatePairingCode(): string {
+	const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // No 0/O/1/I confusion
+	let code = '';
+	const arr = new Uint8Array(6);
+	crypto.getRandomValues(arr);
+	for (let i = 0; i < 6; i++) {
+		code += chars[arr[i] % chars.length];
+	}
+	return code;
+}
+
+export class PluginRelayDO extends DurableObject {
+	private pendingRequests: Map<string, PendingRelay> = new Map();
+	private requestIdCounter = 0;
+
+	// ======================================================================
+	// Hibernation-safe WebSocket retrieval
+	// ======================================================================
+
+	/**
+	 * Get the active plugin WebSocket. Uses ctx.getWebSockets() which
+	 * survives DO hibernation (unlike a class property reference).
+	 */
+	private getPluginWs(): WebSocket | null {
+		const sockets = this.ctx.getWebSockets('plugin');
+		return sockets.length > 0 ? sockets[0] : null;
+	}
+
+	/**
+	 * Incoming fetch handler — dispatches to routes.
+	 */
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname === '/ws/connect') {
+			return this.handlePluginConnect(request);
+		}
+
+		if (url.pathname === '/relay/command') {
+			return this.handleRelayCommand(request);
+		}
+
+		if (url.pathname === '/relay/status') {
+			return this.handleRelayStatus();
+		}
+
+		return new Response('Not found', { status: 404 });
+	}
+
+	// ==========================================================================
+	// WebSocket — plugin connects here
+	// ==========================================================================
+
+	private handlePluginConnect(request: Request): Response {
+		const upgradeHeader = request.headers.get('Upgrade');
+		if (!upgradeHeader || upgradeHeader.toLowerCase() !== 'websocket') {
+			return new Response('Expected WebSocket upgrade', { status: 426 });
+		}
+
+		// Close any existing plugin connection (e.g., re-pairing)
+		const existing = this.getPluginWs();
+		if (existing) {
+			try { existing.close(1000, 'Replaced by new connection'); } catch { /* ignore */ }
+		}
+
+		const pair = new WebSocketPair();
+		const [client, server] = Object.values(pair);
+
+		// Accept with 'plugin' tag — this.ctx.getWebSockets('plugin') retrieves
+		// the socket even after the DO wakes from hibernation.
+		this.ctx.acceptWebSocket(server, ['plugin']);
+
+		return new Response(null, { status: 101, webSocket: client });
+	}
+
+	/**
+	 * Hibernation callback — incoming message from plugin WebSocket.
+	 */
+	async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+		if (typeof message !== 'string') return;
+
+		try {
+			const data = JSON.parse(message);
+
+			// FILE_INFO identification from plugin — persist to DO storage
+			if (data.type === 'FILE_INFO' && data.data) {
+				const fileInfo: RelayFileInfo = {
+					fileName: data.data.fileName,
+					fileKey: data.data.fileKey || null,
+					currentPage: data.data.currentPage,
+					currentPageId: data.data.currentPageId || null,
+					connectedAt: Date.now(),
+				};
+				await this.ctx.storage.put('fileInfo', fileInfo);
+				return;
+			}
+
+			// Event broadcasts from plugin (PAGE_CHANGE, etc.)
+			if (data.type === 'PAGE_CHANGE' && data.data) {
+				const fileInfo = await this.ctx.storage.get<RelayFileInfo>('fileInfo');
+				if (fileInfo) {
+					fileInfo.currentPage = data.data.pageName;
+					fileInfo.currentPageId = data.data.pageId || null;
+					await this.ctx.storage.put('fileInfo', fileInfo);
+				}
+				return;
+			}
+
+			// Response to a relayed command
+			if (data.id && this.pendingRequests.has(data.id)) {
+				const pending = this.pendingRequests.get(data.id)!;
+				clearTimeout(pending.timeoutId);
+				this.pendingRequests.delete(data.id);
+
+				const body = JSON.stringify(data.error
+					? { error: data.error }
+					: { result: data.result });
+
+				pending.resolve(new Response(body, {
+					headers: { 'Content-Type': 'application/json' },
+				}));
+			}
+		} catch {
+			// Malformed message — ignore
+		}
+	}
+
+	/**
+	 * Hibernation callback — WebSocket closed.
+	 */
+	webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): void {
+		this.handleDisconnect();
+	}
+
+	/**
+	 * Hibernation callback — WebSocket error.
+	 */
+	webSocketError(ws: WebSocket, error: unknown): void {
+		this.handleDisconnect();
+	}
+
+	private handleDisconnect(): void {
+		// Clear persisted file info
+		this.ctx.storage.delete('fileInfo');
+
+		// Reject all in-flight commands
+		for (const [id, pending] of this.pendingRequests) {
+			clearTimeout(pending.timeoutId);
+			pending.resolve(new Response(
+				JSON.stringify({ error: 'Plugin disconnected' }),
+				{ status: 502, headers: { 'Content-Type': 'application/json' } },
+			));
+		}
+		this.pendingRequests.clear();
+	}
+
+	// ==========================================================================
+	// Relay — MCP DO sends commands here
+	// ==========================================================================
+
+	private async handleRelayCommand(request: Request): Promise<Response> {
+		const pluginWs = this.getPluginWs();
+		if (!pluginWs) {
+			return new Response(
+				JSON.stringify({ error: 'No plugin connected. User must pair the Desktop Bridge plugin first.' }),
+				{ status: 502, headers: { 'Content-Type': 'application/json' } },
+			);
+		}
+
+		const body = await request.json() as { method: string; params?: Record<string, any>; timeoutMs?: number };
+		const { method, params = {}, timeoutMs = 15000 } = body;
+
+		const id = `relay_${++this.requestIdCounter}_${Date.now()}`;
+
+		// Send command to plugin
+		try {
+			pluginWs.send(JSON.stringify({ id, method, params }));
+		} catch {
+			return new Response(
+				JSON.stringify({ error: 'Failed to send command to plugin — connection may be stale' }),
+				{ status: 502, headers: { 'Content-Type': 'application/json' } },
+			);
+		}
+
+		// Wait for plugin response (the DO stays alive because fetch is active)
+		return new Promise<Response>((resolve) => {
+			const timeoutId = setTimeout(() => {
+				if (this.pendingRequests.has(id)) {
+					this.pendingRequests.delete(id);
+					resolve(new Response(
+						JSON.stringify({ error: `Command ${method} timed out after ${timeoutMs}ms` }),
+						{ status: 504, headers: { 'Content-Type': 'application/json' } },
+					));
+				}
+			}, timeoutMs);
+
+			this.pendingRequests.set(id, { resolve, reject: () => {}, timeoutId });
+		});
+	}
+
+	// ==========================================================================
+	// Status
+	// ==========================================================================
+
+	private async handleRelayStatus(): Promise<Response> {
+		const pluginWs = this.getPluginWs();
+		const fileInfo = await this.ctx.storage.get<RelayFileInfo>('fileInfo');
+
+		return new Response(
+			JSON.stringify({
+				connected: pluginWs !== null,
+				fileInfo: fileInfo || null,
+				pendingCommands: this.pendingRequests.size,
+			}),
+			{ headers: { 'Content-Type': 'application/json' } },
+		);
+	}
+}

--- a/src/core/write-tools.ts
+++ b/src/core/write-tools.ts
@@ -1,0 +1,2532 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { createChildLogger } from "./logger.js";
+
+const logger = createChildLogger({ component: "write-tools" });
+
+/**
+ * Register write/manipulation tools that require a Desktop Bridge connector.
+ * Used by both local mode (src/local.ts) and cloud mode (src/index.ts).
+ */
+export function registerWriteTools(
+	server: McpServer,
+	getDesktopConnector: () => Promise<any>,
+) {
+	// ============================================================================
+	// EXECUTION TOOL
+	// ============================================================================
+
+	server.tool(
+		"figma_execute",
+		`Execute arbitrary JavaScript in Figma's plugin context with full access to the figma API. Use for complex operations not covered by other tools. Requires Desktop Bridge plugin. CAUTION: Can modify your document.
+
+**COMPONENT INSTANCES:** For instances (node.type === 'INSTANCE'), use figma_set_instance_properties — direct text editing FAILS SILENTLY. Check instance.componentProperties for available props (may have #nodeId suffixes).
+
+**RESULT ANALYSIS:** Check resultAnalysis.warning for silent failures (empty arrays, null returns).
+
+**VALIDATION:** After creating/modifying visuals: screenshot with figma_capture_screenshot, check alignment/spacing/proportions, iterate up to 3x.
+
+**PLACEMENT:** Always create components inside a Section or Frame, never on blank canvas. Use parent.insertChild(0, bg) for z-ordering backgrounds behind content.`,
+		{
+			code: z
+				.string()
+				.describe(
+					"JavaScript code to execute. Has access to the 'figma' global object. " +
+						"Example: 'const rect = figma.createRectangle(); rect.resize(100, 100); return { id: rect.id };'",
+				),
+			timeout: z
+				.number()
+				.optional()
+				.default(5000)
+				.describe(
+					"Execution timeout in milliseconds (default: 5000, max: 30000)",
+				),
+		},
+		async ({ code, timeout }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.executeCodeViaUI(
+					code,
+					Math.min(timeout, 30000),
+				);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: result.success,
+									result: result.result,
+									error: result.error,
+									resultAnalysis: result.resultAnalysis,
+									fileContext: result.fileContext,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error(
+					{ error },
+					"Failed to execute code in Figma plugin context",
+				);
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to execute code in Figma plugin context",
+									hint: "Make sure the Desktop Bridge plugin is running in Figma",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// ============================================================================
+	// VARIABLE MANAGEMENT TOOLS
+	// ============================================================================
+
+	// Tool: Update a variable's value
+	server.tool(
+		"figma_update_variable",
+		"Update a single variable's value. For multiple updates, use figma_batch_update_variables instead (10-50x faster). Use figma_get_variables first for IDs. COLOR: hex '#FF0000', FLOAT: number, STRING: text, BOOLEAN: true/false. Requires Desktop Bridge plugin.",
+		{
+			variableId: z
+				.string()
+				.describe(
+					"The variable ID to update (e.g., 'VariableID:123:456'). Get this from figma_get_variables.",
+				),
+			modeId: z
+				.string()
+				.describe(
+					"The mode ID to update the value in (e.g., '1:0'). Get this from the variable's collection modes.",
+				),
+			value: z
+				.union([z.string(), z.number(), z.boolean()])
+				.describe(
+					"The new value. For COLOR: hex string like '#FF0000'. For FLOAT: number. For STRING: text. For BOOLEAN: true/false.",
+				),
+		},
+		async ({ variableId, modeId, value }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.updateVariable(
+					variableId,
+					modeId,
+					value,
+				);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Variable "${result.variable.name}" updated successfully`,
+									variable: result.variable,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to update variable");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to update variable",
+									hint: "Make sure the Desktop Bridge plugin is running and the variable ID is correct",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Create a new variable
+	server.tool(
+		"figma_create_variable",
+		"Create a single Figma variable. For multiple variables, use figma_batch_create_variables instead (10-50x faster). Use figma_get_variables first to get collection IDs. Supports COLOR, FLOAT, STRING, BOOLEAN. Requires Desktop Bridge plugin.",
+		{
+			name: z
+				.string()
+				.describe("Name for the new variable (e.g., 'primary-blue')"),
+			collectionId: z
+				.string()
+				.describe(
+					"The collection ID to create the variable in (e.g., 'VariableCollectionId:123:456'). Get this from figma_get_variables.",
+				),
+			resolvedType: z
+				.enum(["COLOR", "FLOAT", "STRING", "BOOLEAN"])
+				.describe("The variable type: COLOR, FLOAT, STRING, or BOOLEAN"),
+			description: z
+				.string()
+				.optional()
+				.describe("Optional description for the variable"),
+			valuesByMode: z
+				.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+				.optional()
+				.describe(
+					"Optional initial values by mode ID. Example: { '1:0': '#FF0000', '1:1': '#0000FF' }",
+				),
+		},
+		async ({
+			name,
+			collectionId,
+			resolvedType,
+			description,
+			valuesByMode,
+		}) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.createVariable(
+					name,
+					collectionId,
+					resolvedType,
+					{
+						description,
+						valuesByMode,
+					},
+				);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Variable "${name}" created successfully`,
+									variable: result.variable,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to create variable");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to create variable",
+									hint: "Make sure the Desktop Bridge plugin is running and the collection ID is correct",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Create a new variable collection
+	server.tool(
+		"figma_create_variable_collection",
+		"Create an empty variable collection. To create a collection WITH variables and modes in one step, use figma_setup_design_tokens instead. Requires Desktop Bridge plugin.",
+		{
+			name: z
+				.string()
+				.describe("Name for the new collection (e.g., 'Brand Colors')"),
+			initialModeName: z
+				.string()
+				.optional()
+				.describe(
+					"Name for the initial mode (default mode is created automatically). Example: 'Light'",
+				),
+			additionalModes: z
+				.array(z.string())
+				.optional()
+				.describe(
+					"Additional mode names to create. Example: ['Dark', 'High Contrast']",
+				),
+		},
+		async ({ name, initialModeName, additionalModes }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.createVariableCollection(name, {
+					initialModeName,
+					additionalModes,
+				});
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Collection "${name}" created successfully`,
+									collection: result.collection,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to create collection");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to create variable collection",
+									hint: "Make sure the Desktop Bridge plugin is running in Figma",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Delete a variable
+	server.tool(
+		"figma_delete_variable",
+		"Delete a Figma variable. WARNING: This is a destructive operation that cannot be undone (except with Figma's undo). Use figma_get_variables first to get variable IDs. Requires the Desktop Bridge plugin to be running.",
+		{
+			variableId: z
+				.string()
+				.describe(
+					"The variable ID to delete (e.g., 'VariableID:123:456'). Get this from figma_get_variables.",
+				),
+		},
+		async ({ variableId }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.deleteVariable(variableId);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Variable "${result.deleted.name}" deleted successfully`,
+									deleted: result.deleted,
+									timestamp: Date.now(),
+									warning:
+										"This action cannot be undone programmatically. Use Figma's Edit > Undo if needed.",
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to delete variable");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to delete variable",
+									hint: "Make sure the Desktop Bridge plugin is running and the variable ID is correct",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Delete a variable collection
+	server.tool(
+		"figma_delete_variable_collection",
+		"Delete a Figma variable collection and ALL its variables. WARNING: This is a destructive operation that deletes all variables in the collection and cannot be undone (except with Figma's undo). Requires the Desktop Bridge plugin to be running.",
+		{
+			collectionId: z
+				.string()
+				.describe(
+					"The collection ID to delete (e.g., 'VariableCollectionId:123:456'). Get this from figma_get_variables.",
+				),
+		},
+		async ({ collectionId }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.deleteVariableCollection(collectionId);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Collection "${result.deleted.name}" and ${result.deleted.variableCount} variables deleted successfully`,
+									deleted: result.deleted,
+									timestamp: Date.now(),
+									warning:
+										"This action cannot be undone programmatically. Use Figma's Edit > Undo if needed.",
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to delete collection");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to delete variable collection",
+									hint: "Make sure the Desktop Bridge plugin is running and the collection ID is correct",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Rename a variable
+	server.tool(
+		"figma_rename_variable",
+		"Rename an existing Figma variable. This updates the variable's name while preserving all its values and settings. Requires the Desktop Bridge plugin to be running.",
+		{
+			variableId: z
+				.string()
+				.describe(
+					"The variable ID to rename (e.g., 'VariableID:123:456'). Get this from figma_get_variables.",
+				),
+			newName: z
+				.string()
+				.describe(
+					"The new name for the variable. Can include slashes for grouping (e.g., 'colors/primary/background').",
+				),
+		},
+		async ({ variableId, newName }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.renameVariable(variableId, newName);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Variable renamed from "${result.oldName}" to "${result.variable.name}"`,
+									oldName: result.oldName,
+									variable: result.variable,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to rename variable");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to rename variable",
+									hint: "Make sure the Desktop Bridge plugin is running and the variable ID is correct",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Add a mode to a collection
+	server.tool(
+		"figma_add_mode",
+		"Add a new mode to an existing Figma variable collection. Modes allow variables to have different values for different contexts (e.g., Light/Dark themes, device sizes). Requires the Desktop Bridge plugin to be running.",
+		{
+			collectionId: z
+				.string()
+				.describe(
+					"The collection ID to add the mode to (e.g., 'VariableCollectionId:123:456'). Get this from figma_get_variables.",
+				),
+			modeName: z
+				.string()
+				.describe(
+					"The name for the new mode (e.g., 'Dark', 'Mobile', 'High Contrast').",
+				),
+		},
+		async ({ collectionId, modeName }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.addMode(collectionId, modeName);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Mode "${modeName}" added to collection "${result.collection.name}"`,
+									newMode: result.newMode,
+									collection: result.collection,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to add mode");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to add mode to collection",
+									hint: "Make sure the Desktop Bridge plugin is running, the collection ID is correct, and you haven't exceeded Figma's mode limit",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Rename a mode in a collection
+	server.tool(
+		"figma_rename_mode",
+		"Rename an existing mode in a Figma variable collection. Requires the Desktop Bridge plugin to be running.",
+		{
+			collectionId: z
+				.string()
+				.describe(
+					"The collection ID containing the mode (e.g., 'VariableCollectionId:123:456'). Get this from figma_get_variables.",
+				),
+			modeId: z
+				.string()
+				.describe(
+					"The mode ID to rename (e.g., '123:0'). Get this from the collection's modes array in figma_get_variables.",
+				),
+			newName: z
+				.string()
+				.describe(
+					"The new name for the mode (e.g., 'Dark Theme', 'Tablet').",
+				),
+		},
+		async ({ collectionId, modeId, newName }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.renameMode(
+					collectionId,
+					modeId,
+					newName,
+				);
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Mode renamed from "${result.oldName}" to "${newName}"`,
+									oldName: result.oldName,
+									collection: result.collection,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to rename mode");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to rename mode",
+									hint: "Make sure the Desktop Bridge plugin is running, the collection ID and mode ID are correct",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// ============================================================================
+	// BATCH OPERATIONS (Performance-Optimized)
+	// ============================================================================
+	// Execute multiple variable operations in a single roundtrip,
+	// reducing per-operation overhead from ~60-170ms to near-zero.
+	// Use these instead of calling individual tools repeatedly.
+
+	// Tool: Batch create variables
+	server.tool(
+		"figma_batch_create_variables",
+		"Create multiple variables in one operation. Use instead of calling figma_create_variable repeatedly — up to 50x faster for bulk operations. Get collection IDs from figma_get_variables first. Requires Desktop Bridge plugin.",
+		{
+			collectionId: z
+				.string()
+				.describe(
+					"Collection ID to create all variables in (e.g., 'VariableCollectionId:123:456')",
+				),
+			variables: z
+				.array(
+					z.object({
+						name: z.string().describe("Variable name (e.g., 'primary-blue')"),
+						resolvedType: z
+							.enum(["COLOR", "FLOAT", "STRING", "BOOLEAN"])
+							.describe("Variable type"),
+						description: z
+							.string()
+							.optional()
+							.describe("Optional description"),
+						valuesByMode: z
+							.record(
+								z.string(),
+								z.union([z.string(), z.number(), z.boolean()]),
+							)
+							.optional()
+							.describe(
+								"Values by mode ID. For COLOR: hex like '#FF0000'. Example: { '1:0': '#FF0000' }",
+							),
+					}),
+				)
+				.min(1)
+				.max(100)
+				.describe("Array of variables to create (1-100)"),
+		},
+		async ({ collectionId, variables }) => {
+			try {
+				const connector = await getDesktopConnector();
+
+				const script = `
+const results = [];
+const collectionId = ${JSON.stringify(collectionId)};
+const vars = ${JSON.stringify(variables)};
+
+function hexToRgba(hex) {
+  hex = hex.replace('#', '');
+  if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
+  return {
+    r: parseInt(hex.substring(0, 2), 16) / 255,
+    g: parseInt(hex.substring(2, 4), 16) / 255,
+    b: parseInt(hex.substring(4, 6), 16) / 255,
+    a: hex.length === 8 ? parseInt(hex.substring(6, 8), 16) / 255 : 1
+  };
+}
+
+const collection = await figma.variables.getVariableCollectionByIdAsync(collectionId);
+if (!collection) return { created: 0, failed: vars.length, results: vars.map(v => ({ success: false, name: v.name, error: 'Collection not found: ' + collectionId })) };
+
+for (const v of vars) {
+  try {
+    const variable = figma.variables.createVariable(v.name, collection, v.resolvedType);
+    if (v.description) variable.description = v.description;
+    if (v.valuesByMode) {
+      for (const [modeId, value] of Object.entries(v.valuesByMode)) {
+        const processed = v.resolvedType === 'COLOR' && typeof value === 'string' ? hexToRgba(value) : value;
+        variable.setValueForMode(modeId, processed);
+      }
+    }
+    results.push({ success: true, name: v.name, id: variable.id });
+  } catch (err) {
+    results.push({ success: false, name: v.name, error: String(err) });
+  }
+}
+
+return {
+  created: results.filter(r => r.success).length,
+  failed: results.filter(r => !r.success).length,
+  results
+};`;
+
+				const timeout = Math.max(5000, variables.length * 200);
+				const result = await connector.executeCodeViaUI(
+					script,
+					Math.min(timeout, 30000),
+				);
+
+				if (result.error) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify(
+									{
+										error: result.error,
+										message:
+											"Batch create failed during execution",
+										hint: "Check that the collection ID is valid and the Desktop Bridge plugin is running",
+									},
+								),
+							},
+						],
+						isError: true,
+					};
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Batch created ${result.result?.created ?? 0} variables (${result.result?.failed ?? 0} failed)`,
+									...result.result,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to batch create variables");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error
+											? error.message
+											: String(error),
+									message: "Failed to batch create variables",
+									hint: "Make sure the Desktop Bridge plugin is running and the collection ID is correct",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Batch update variables
+	server.tool(
+		"figma_batch_update_variables",
+		"Update multiple variable values in one operation. Use instead of calling figma_update_variable repeatedly — up to 50x faster for bulk updates. Get variable/mode IDs from figma_get_variables first. Requires Desktop Bridge plugin.",
+		{
+			updates: z
+				.array(
+					z.object({
+						variableId: z
+							.string()
+							.describe(
+								"Variable ID (e.g., 'VariableID:123:456')",
+							),
+						modeId: z
+							.string()
+							.describe("Mode ID (e.g., '1:0')"),
+						value: z
+							.union([z.string(), z.number(), z.boolean()])
+							.describe(
+								"New value. COLOR: hex like '#FF0000'. FLOAT: number. STRING: text. BOOLEAN: true/false.",
+							),
+					}),
+				)
+				.min(1)
+				.max(100)
+				.describe("Array of updates to apply (1-100)"),
+		},
+		async ({ updates }) => {
+			try {
+				const connector = await getDesktopConnector();
+
+				const script = `
+const results = [];
+const updates = ${JSON.stringify(updates)};
+
+function hexToRgba(hex) {
+  hex = hex.replace('#', '');
+  if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
+  return {
+    r: parseInt(hex.substring(0, 2), 16) / 255,
+    g: parseInt(hex.substring(2, 4), 16) / 255,
+    b: parseInt(hex.substring(4, 6), 16) / 255,
+    a: hex.length === 8 ? parseInt(hex.substring(6, 8), 16) / 255 : 1
+  };
+}
+
+for (const u of updates) {
+  try {
+    const variable = await figma.variables.getVariableByIdAsync(u.variableId);
+    if (!variable) throw new Error('Variable not found: ' + u.variableId);
+    const isColor = variable.resolvedType === 'COLOR';
+    const processed = isColor && typeof u.value === 'string' ? hexToRgba(u.value) : u.value;
+    variable.setValueForMode(u.modeId, processed);
+    results.push({ success: true, variableId: u.variableId, name: variable.name });
+  } catch (err) {
+    results.push({ success: false, variableId: u.variableId, error: String(err) });
+  }
+}
+
+return {
+  updated: results.filter(r => r.success).length,
+  failed: results.filter(r => !r.success).length,
+  results
+};`;
+
+				const timeout = Math.max(5000, updates.length * 150);
+				const result = await connector.executeCodeViaUI(
+					script,
+					Math.min(timeout, 30000),
+				);
+
+				if (result.error) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify(
+									{
+										error: result.error,
+										message:
+											"Batch update failed during execution",
+										hint: "Check that variable IDs and mode IDs are valid",
+									},
+								),
+							},
+						],
+						isError: true,
+					};
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Batch updated ${result.result?.updated ?? 0} variables (${result.result?.failed ?? 0} failed)`,
+									...result.result,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to batch update variables");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error
+											? error.message
+											: String(error),
+									message: "Failed to batch update variables",
+									hint: "Make sure the Desktop Bridge plugin is running and variable/mode IDs are correct",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Setup design tokens (collection + modes + variables atomically)
+	server.tool(
+		"figma_setup_design_tokens",
+		"Create a complete design token structure in one operation: collection, modes, and all variables. Ideal for importing CSS custom properties or design tokens into Figma. Requires Desktop Bridge plugin.",
+		{
+			collectionName: z
+				.string()
+				.describe("Name for the token collection (e.g., 'Brand Tokens')"),
+			modes: z
+				.array(z.string())
+				.min(1)
+				.max(4)
+				.describe(
+					"Mode names (first becomes default). Example: ['Light', 'Dark']",
+				),
+			tokens: z
+				.array(
+					z.object({
+						name: z
+							.string()
+							.describe("Token name (e.g., 'color/primary')"),
+						resolvedType: z
+							.enum(["COLOR", "FLOAT", "STRING", "BOOLEAN"])
+							.describe("Token type"),
+						description: z
+							.string()
+							.optional()
+							.describe("Optional description"),
+						values: z
+							.record(
+								z.string(),
+								z.union([z.string(), z.number(), z.boolean()]),
+							)
+							.describe(
+								"Values keyed by mode NAME (not ID). Example: { 'Light': '#FFFFFF', 'Dark': '#000000' }",
+							),
+					}),
+				)
+				.min(1)
+				.max(100)
+				.describe("Token definitions (1-100)"),
+		},
+		async ({ collectionName, modes, tokens }) => {
+			try {
+				const connector = await getDesktopConnector();
+
+				const script = `
+const collectionName = ${JSON.stringify(collectionName)};
+const modeNames = ${JSON.stringify(modes)};
+const tokenDefs = ${JSON.stringify(tokens)};
+
+function hexToRgba(hex) {
+  hex = hex.replace('#', '');
+  if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
+  return {
+    r: parseInt(hex.substring(0, 2), 16) / 255,
+    g: parseInt(hex.substring(2, 4), 16) / 255,
+    b: parseInt(hex.substring(4, 6), 16) / 255,
+    a: hex.length === 8 ? parseInt(hex.substring(6, 8), 16) / 255 : 1
+  };
+}
+
+// Step 1: Create collection
+const collection = figma.variables.createVariableCollection(collectionName);
+const modeMap = {};
+
+// Step 2: Set up modes - first mode uses the default mode that was auto-created
+const defaultModeId = collection.modes[0].modeId;
+collection.renameMode(defaultModeId, modeNames[0]);
+modeMap[modeNames[0]] = defaultModeId;
+
+for (let i = 1; i < modeNames.length; i++) {
+  const newModeId = collection.addMode(modeNames[i]);
+  modeMap[modeNames[i]] = newModeId;
+}
+
+// Step 3: Create all variables with values
+const results = [];
+for (const t of tokenDefs) {
+  try {
+    const variable = figma.variables.createVariable(t.name, collection, t.resolvedType);
+    if (t.description) variable.description = t.description;
+    for (const [modeName, value] of Object.entries(t.values)) {
+      const modeId = modeMap[modeName];
+      if (!modeId) { results.push({ success: false, name: t.name, error: 'Unknown mode: ' + modeName }); continue; }
+      const processed = t.resolvedType === 'COLOR' && typeof value === 'string' ? hexToRgba(value) : value;
+      variable.setValueForMode(modeId, processed);
+    }
+    results.push({ success: true, name: t.name, id: variable.id });
+  } catch (err) {
+    results.push({ success: false, name: t.name, error: String(err) });
+  }
+}
+
+return {
+  collectionId: collection.id,
+  collectionName: collectionName,
+  modes: modeMap,
+  created: results.filter(r => r.success).length,
+  failed: results.filter(r => !r.success).length,
+  results
+};`;
+
+				const timeout = Math.max(
+					10000,
+					tokens.length * 200 + modes.length * 500,
+				);
+				const result = await connector.executeCodeViaUI(
+					script,
+					Math.min(timeout, 30000),
+				);
+
+				if (result.error) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify(
+									{
+										error: result.error,
+										message:
+											"Design token setup failed during execution",
+										hint: "Check the token definitions and ensure the Desktop Bridge plugin is running",
+									},
+								),
+							},
+						],
+						isError: true,
+					};
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Created collection "${collectionName}" with ${modes.length} mode(s) and ${result.result?.created ?? 0} tokens`,
+									...result.result,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to setup design tokens");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error
+											? error.message
+											: String(error),
+									message: "Failed to setup design tokens",
+									hint: "Make sure the Desktop Bridge plugin is running in Figma",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// ============================================================================
+	// COMPONENT INSTANTIATION & PROPERTY TOOLS
+	// ============================================================================
+
+	// Tool: Instantiate Component
+	server.tool(
+		"figma_instantiate_component",
+		`Create an instance of a component from the design system.
+
+**CRITICAL: Always pass BOTH componentKey AND nodeId together!**
+Search results return both identifiers. Pass both so the tool can automatically fall back to nodeId if the component isn't published to a library. Most local/unpublished components require nodeId.
+
+**IMPORTANT: Always re-search before instantiating!**
+NodeIds are session-specific and may be stale from previous conversations. ALWAYS search for components at the start of each design session to get current, valid identifiers.
+
+**VISUAL VALIDATION WORKFLOW:**
+After instantiating components, use figma_take_screenshot to verify the result looks correct. Check placement, sizing, and visual balance.`,
+		{
+			componentKey: z
+				.string()
+				.optional()
+				.describe(
+					"The component key from search results. Pass this WITH nodeId for automatic fallback.",
+				),
+			nodeId: z
+				.string()
+				.optional()
+				.describe(
+					"The node ID from search results. ALWAYS pass this alongside componentKey - most local components need it.",
+				),
+			variant: z
+				.record(z.string())
+				.optional()
+				.describe(
+					"Variant properties to set (e.g., { Type: 'Simple', State: 'Active' })",
+				),
+			overrides: z
+				.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+				.optional()
+				.describe(
+					"Property overrides (e.g., { 'Button Label': 'Click Me' })",
+				),
+			position: z
+				.object({
+					x: z.number(),
+					y: z.number(),
+				})
+				.optional()
+				.describe("Position on canvas (default: 0, 0)"),
+			parentId: z
+				.string()
+				.optional()
+				.describe("Parent node ID to append the instance to"),
+		},
+		async ({
+			componentKey,
+			nodeId,
+			variant,
+			overrides,
+			position,
+			parentId,
+		}) => {
+			try {
+				if (!componentKey && !nodeId) {
+					throw new Error("Either componentKey or nodeId is required");
+				}
+				const connector = await getDesktopConnector();
+				const result = await connector.instantiateComponent(
+					componentKey || "",
+					{
+						nodeId,
+						position,
+						overrides,
+						variant,
+						parentId,
+					},
+				);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to instantiate component");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Component instantiated successfully",
+									instance: result.instance,
+									timestamp: Date.now(),
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to instantiate component");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									message: "Failed to instantiate component",
+									hint: "Make sure the component key is correct and the Desktop Bridge plugin is running",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// ============================================================================
+	// Component Property Management Tools
+	// ============================================================================
+
+	// Tool: Set Node Description
+	server.tool(
+		"figma_set_description",
+		"Set the description text on a component, component set, or style. Descriptions appear in Dev Mode and help document design intent. Supports plain text and markdown formatting.",
+		{
+			nodeId: z
+				.string()
+				.describe(
+					"The node ID of the component or style to update (e.g., '123:456')",
+				),
+			description: z.string().describe("The plain text description to set"),
+			descriptionMarkdown: z
+				.string()
+				.optional()
+				.describe("Optional rich text description using markdown formatting"),
+		},
+		async ({ nodeId, description, descriptionMarkdown }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.setNodeDescription(
+					nodeId,
+					description,
+					descriptionMarkdown,
+				);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to set description");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Description set successfully",
+									node: result.node,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to set description");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									hint: "Make sure the node supports descriptions (components, component sets, styles)",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Add Component Property
+	server.tool(
+		"figma_add_component_property",
+		"Add a new component property to a component or component set. Properties enable dynamic content and behavior in component instances. Supported types: BOOLEAN (toggle), TEXT (string), INSTANCE_SWAP (component swap), VARIANT (variant selection).",
+		{
+			nodeId: z.string().describe("The component or component set node ID"),
+			propertyName: z
+				.string()
+				.describe(
+					"Name for the new property (e.g., 'Show Icon', 'Button Label')",
+				),
+			type: z
+				.enum(["BOOLEAN", "TEXT", "INSTANCE_SWAP", "VARIANT"])
+				.describe(
+					"Property type: BOOLEAN for toggles, TEXT for strings, INSTANCE_SWAP for component swaps, VARIANT for variant selection",
+				),
+			defaultValue: z
+				.union([z.string(), z.number(), z.boolean()])
+				.describe(
+					"Default value for the property. BOOLEAN: true/false, TEXT: string, INSTANCE_SWAP: component key, VARIANT: variant value",
+				),
+		},
+		async ({ nodeId, propertyName, type, defaultValue }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.addComponentProperty(
+					nodeId,
+					propertyName,
+					type,
+					defaultValue,
+				);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to add property");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Component property added",
+									propertyName: result.propertyName,
+									hint: "The property name includes a unique suffix (e.g., 'Show Icon#123:456'). Use the full name for editing/deleting.",
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to add component property");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									hint: "Cannot add properties to variant components. Add to the parent component set instead.",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Edit Component Property
+	server.tool(
+		"figma_edit_component_property",
+		"Edit an existing component property. Can change the name, default value, or preferred values (for INSTANCE_SWAP). Use the full property name including the unique suffix.",
+		{
+			nodeId: z.string().describe("The component or component set node ID"),
+			propertyName: z
+				.string()
+				.describe(
+					"The full property name with suffix (e.g., 'Show Icon#123:456')",
+				),
+			newValue: z
+				.object({
+					name: z.string().optional().describe("New name for the property"),
+					defaultValue: z
+						.union([z.string(), z.number(), z.boolean()])
+						.optional()
+						.describe("New default value"),
+					preferredValues: z
+						.array(
+							z.object({
+								type: z
+									.enum(["COMPONENT", "COMPONENT_SET"])
+									.describe("Type of preferred value"),
+								key: z.string().describe("Component or component set key"),
+							}),
+						)
+						.optional()
+						.describe("Preferred values (INSTANCE_SWAP only)"),
+				})
+				.describe("Object with the values to update"),
+		},
+		async ({ nodeId, propertyName, newValue }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.editComponentProperty(
+					nodeId,
+					propertyName,
+					newValue,
+				);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to edit property");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Component property updated",
+									propertyName: result.propertyName,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to edit component property");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Delete Component Property
+	server.tool(
+		"figma_delete_component_property",
+		"Delete a component property. Only works with BOOLEAN, TEXT, and INSTANCE_SWAP properties (not VARIANT). This is a destructive operation.",
+		{
+			nodeId: z.string().describe("The component or component set node ID"),
+			propertyName: z
+				.string()
+				.describe(
+					"The full property name with suffix (e.g., 'Show Icon#123:456')",
+				),
+		},
+		async ({ nodeId, propertyName }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.deleteComponentProperty(
+					nodeId,
+					propertyName,
+				);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to delete property");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Component property deleted",
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to delete component property");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									hint: "Cannot delete VARIANT properties. Only BOOLEAN, TEXT, and INSTANCE_SWAP can be deleted.",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// ============================================================================
+	// Node Manipulation Tools
+	// ============================================================================
+
+	// Tool: Resize Node
+	server.tool(
+		"figma_resize_node",
+		"Resize a node to specific dimensions. By default respects child constraints; use withConstraints=false to ignore them.",
+		{
+			nodeId: z.string().describe("The node ID to resize"),
+			width: z.number().describe("New width in pixels"),
+			height: z.number().describe("New height in pixels"),
+			withConstraints: z
+				.boolean()
+				.optional()
+				.default(true)
+				.describe(
+					"Whether to apply child constraints during resize (default: true)",
+				),
+		},
+		async ({ nodeId, width, height, withConstraints }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.resizeNode(
+					nodeId,
+					width,
+					height,
+					withConstraints,
+				);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to resize node");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Node resized to ${width}x${height}`,
+									node: result.node,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to resize node");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Move Node
+	server.tool(
+		"figma_move_node",
+		"Move a node to a new position within its parent.",
+		{
+			nodeId: z.string().describe("The node ID to move"),
+			x: z.number().describe("New X position"),
+			y: z.number().describe("New Y position"),
+		},
+		async ({ nodeId, x, y }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.moveNode(nodeId, x, y);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to move node");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Node moved to (${x}, ${y})`,
+									node: result.node,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to move node");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Set Node Fills
+	server.tool(
+		"figma_set_fills",
+		"Set the fill colors on a node. Accepts hex color strings (e.g., '#FF0000') or full paint objects.",
+		{
+			nodeId: z.string().describe("The node ID to modify"),
+			fills: z
+				.array(
+					z.object({
+						type: z
+							.literal("SOLID")
+							.describe("Fill type (currently only SOLID supported)"),
+						color: z
+							.string()
+							.describe(
+								"Hex color string (e.g., '#FF0000', '#FF000080' for transparency)",
+							),
+						opacity: z
+							.number()
+							.optional()
+							.describe("Opacity 0-1 (default: 1)"),
+					}),
+				)
+				.describe("Array of fill objects"),
+		},
+		async ({ nodeId, fills }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.setNodeFills(nodeId, fills);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to set fills");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Fills updated",
+									node: result.node,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to set fills");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Set Node Strokes
+	server.tool(
+		"figma_set_strokes",
+		"Set the stroke (border) on a node. Accepts hex color strings and optional stroke weight.",
+		{
+			nodeId: z.string().describe("The node ID to modify"),
+			strokes: z
+				.array(
+					z.object({
+						type: z.literal("SOLID").describe("Stroke type"),
+						color: z.string().describe("Hex color string"),
+						opacity: z.number().optional().describe("Opacity 0-1"),
+					}),
+				)
+				.describe("Array of stroke objects"),
+			strokeWeight: z
+				.number()
+				.optional()
+				.describe("Stroke thickness in pixels"),
+		},
+		async ({ nodeId, strokes, strokeWeight }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.setNodeStrokes(
+					nodeId,
+					strokes,
+					strokeWeight,
+				);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to set strokes");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Strokes updated",
+									node: result.node,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to set strokes");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Clone Node
+	server.tool(
+		"figma_clone_node",
+		"Duplicate a node. The clone is placed at a slight offset from the original.",
+		{
+			nodeId: z.string().describe("The node ID to clone"),
+		},
+		async ({ nodeId }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.cloneNode(nodeId);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to clone node");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Node cloned",
+									clonedNode: result.node,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to clone node");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Delete Node
+	server.tool(
+		"figma_delete_node",
+		"Delete a node from the canvas. WARNING: This is a destructive operation (can be undone with Figma's undo).",
+		{
+			nodeId: z.string().describe("The node ID to delete"),
+		},
+		async ({ nodeId }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.deleteNode(nodeId);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to delete node");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Node deleted",
+									deleted: result.deleted,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to delete node");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Rename Node
+	server.tool(
+		"figma_rename_node",
+		"Rename a node in the layer panel.",
+		{
+			nodeId: z.string().describe("The node ID to rename"),
+			newName: z.string().describe("The new name for the node"),
+		},
+		async ({ nodeId, newName }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.renameNode(nodeId, newName);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to rename node");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Node renamed to "${newName}"`,
+									node: result.node,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to rename node");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Set Text Content
+	server.tool(
+		"figma_set_text",
+		"Set the text content of a text node. Optionally adjust font size.",
+		{
+			nodeId: z.string().describe("The text node ID"),
+			text: z.string().describe("The new text content"),
+			fontSize: z.number().optional().describe("Optional font size to set"),
+		},
+		async ({ nodeId, text, fontSize }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.setTextContent(
+					nodeId,
+					text,
+					fontSize ? { fontSize } : undefined,
+				);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to set text");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: "Text content updated",
+									node: result.node,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to set text content");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									hint: "Make sure the node is a TEXT node",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// Tool: Create Child Node
+	server.tool(
+		"figma_create_child",
+		"Create a new child node inside a parent container. Useful for adding shapes, text, or frames to existing structures.",
+		{
+			parentId: z.string().describe("The parent node ID"),
+			nodeType: z
+				.enum(["RECTANGLE", "ELLIPSE", "FRAME", "TEXT", "LINE"])
+				.describe("Type of node to create"),
+			properties: z
+				.object({
+					name: z.string().optional().describe("Name for the new node"),
+					x: z.number().optional().describe("X position within parent"),
+					y: z.number().optional().describe("Y position within parent"),
+					width: z.number().optional().describe("Width (default: 100)"),
+					height: z.number().optional().describe("Height (default: 100)"),
+					fills: z
+						.array(
+							z.object({
+								type: z.literal("SOLID"),
+								color: z.string(),
+							}),
+						)
+						.optional()
+						.describe("Fill colors (hex strings)"),
+					text: z
+						.string()
+						.optional()
+						.describe("Text content (for TEXT nodes only)"),
+				})
+				.optional()
+				.describe("Properties for the new node"),
+		},
+		async ({ parentId, nodeType, properties }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.createChildNode(
+					parentId,
+					nodeType,
+					properties,
+				);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to create node");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									success: true,
+									message: `Created ${nodeType} node`,
+									node: result.node,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to create child node");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									hint: "Make sure the parent node supports children (frames, groups, etc.)",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	// ============================================================================
+	// Component Set Arrangement Tool
+	// ============================================================================
+
+	// Tool: Arrange Component Set (Professional Layout with Native Visualization)
+	// Recreates component set using figma.combineAsVariants() for proper purple dashed frame
+	server.tool(
+		"figma_arrange_component_set",
+		`Organize a component set with Figma's native purple dashed visualization. Use after creating variants, adding states (hover/disabled/pressed), or when component sets need cleanup.
+
+Recreates the set using figma.combineAsVariants() for proper Figma integration, applies purple dashed border styling, and arranges variants in a labeled grid (columns = last property like State, rows = other properties like Type+Size). Creates a white container with title, row/column labels, and the component set.`,
+		{
+			componentSetId: z
+				.string()
+				.optional()
+				.describe(
+					"Node ID of the component set to arrange. If not provided, will look for a selected component set.",
+				),
+			componentSetName: z
+				.string()
+				.optional()
+				.describe(
+					"Name of the component set to find. Used if componentSetId not provided.",
+				),
+			options: z
+				.object({
+					gap: z
+						.number()
+						.optional()
+						.default(24)
+						.describe("Gap between grid cells in pixels (default: 24)"),
+					cellPadding: z
+						.number()
+						.optional()
+						.default(20)
+						.describe(
+							"Padding inside each cell around the variant (default: 20)",
+						),
+					columnProperty: z
+						.string()
+						.optional()
+						.describe(
+							"Property to use for columns (default: auto-detect last property, usually 'State')",
+						),
+				})
+				.optional()
+				.describe("Layout options"),
+		},
+		async ({ componentSetId, componentSetName, options }) => {
+			try {
+				const connector = await getDesktopConnector();
+
+				// Build the code to execute in Figma
+				const code = `
+// ============================================================================
+// COMPONENT SET ARRANGEMENT WITH PROPER LABELS AND CONTAINER
+// Creates: White container frame -> Row labels (left) -> Column headers (top) -> Component set (center)
+// Uses auto-layout for proper alignment of labels with grid cells
+// ============================================================================
+
+// Configuration
+const config = ${JSON.stringify(options || {})};
+const gap = config.gap ?? 24;
+const cellPadding = config.cellPadding ?? 20;
+const columnProperty = config.columnProperty || null;
+
+// Layout constants
+const LABEL_FONT_SIZE = 12;
+const LABEL_COLOR = { r: 0.4, g: 0.4, b: 0.4 };  // Gray text
+const TITLE_FONT_SIZE = 24;
+const TITLE_COLOR = { r: 0.1, g: 0.1, b: 0.1 };  // Dark text
+const CONTAINER_PADDING = 40;
+const LABEL_GAP = 16;  // Gap between labels and component set
+const COLUMN_HEADER_HEIGHT = 32;
+
+// Find the component set
+let componentSet = null;
+const csId = ${JSON.stringify(componentSetId || null)};
+const csName = ${JSON.stringify(componentSetName || null)};
+
+if (csId) {
+	componentSet = await figma.getNodeByIdAsync(csId);
+} else if (csName) {
+	const allNodes = figma.currentPage.findAll(n => n.type === "COMPONENT_SET" && n.name === csName);
+	componentSet = allNodes[0];
+} else {
+	const selection = figma.currentPage.selection;
+	componentSet = selection.find(n => n.type === "COMPONENT_SET");
+}
+
+if (!componentSet || componentSet.type !== "COMPONENT_SET") {
+	return { error: "Component set not found. Provide componentSetId, componentSetName, or select a component set." };
+}
+
+const page = figma.currentPage;
+const csOriginalX = componentSet.x;
+const csOriginalY = componentSet.y;
+const csOriginalName = componentSet.name;
+
+// Get all variant components
+const variants = componentSet.children.filter(n => n.type === "COMPONENT");
+if (variants.length === 0) {
+	return { error: "No variants found in component set" };
+}
+
+// Parse variant properties from names
+const parseVariantName = (name) => {
+	const props = {};
+	const parts = name.split(", ");
+	for (const part of parts) {
+		const [key, value] = part.split("=");
+		if (key && value) {
+			props[key.trim()] = value.trim();
+		}
+	}
+	return props;
+};
+
+// Collect all properties and their unique values (preserving order)
+const propertyValues = {};
+const propertyOrder = [];
+for (const variant of variants) {
+	const props = parseVariantName(variant.name);
+	for (const [key, value] of Object.entries(props)) {
+		if (!propertyValues[key]) {
+			propertyValues[key] = new Set();
+			propertyOrder.push(key);
+		}
+		propertyValues[key].add(value);
+	}
+}
+for (const key of Object.keys(propertyValues)) {
+	propertyValues[key] = Array.from(propertyValues[key]);
+}
+
+// Determine grid structure: columns = last property (usually State), rows = other properties
+const columnProp = columnProperty || propertyOrder[propertyOrder.length - 1];
+const columnValues = propertyValues[columnProp] || [];
+const rowProps = propertyOrder.filter(p => p !== columnProp);
+
+// Generate all row combinations
+const generateRowCombinations = (props, values) => {
+	if (props.length === 0) return [{}];
+	if (props.length === 1) {
+		return values[props[0]].map(v => ({ [props[0]]: v }));
+	}
+	const result = [];
+	const firstProp = props[0];
+	const restProps = props.slice(1);
+	const restCombos = generateRowCombinations(restProps, values);
+	for (const value of values[firstProp]) {
+		for (const combo of restCombos) {
+			result.push({ [firstProp]: value, ...combo });
+		}
+	}
+	return result;
+};
+const rowCombinations = generateRowCombinations(rowProps, propertyValues);
+
+const totalCols = columnValues.length;
+const totalRows = rowCombinations.length;
+
+// Calculate max variant dimensions
+let maxVariantWidth = 0;
+let maxVariantHeight = 0;
+for (const v of variants) {
+	if (v.width > maxVariantWidth) maxVariantWidth = v.width;
+	if (v.height > maxVariantHeight) maxVariantHeight = v.height;
+}
+
+// Calculate cell dimensions (each cell in the grid)
+const cellWidth = Math.ceil(maxVariantWidth + cellPadding);
+const cellHeight = Math.ceil(maxVariantHeight + cellPadding);
+
+// Calculate component set dimensions
+const edgePadding = 24;  // Padding inside component set
+const csWidth = (totalCols * cellWidth) + ((totalCols - 1) * gap) + (edgePadding * 2);
+const csHeight = (totalRows * cellHeight) + ((totalRows - 1) * gap) + (edgePadding * 2);
+
+// ============================================================================
+// STEP 1: Remove old labels and container frames from previous arrangements
+// ============================================================================
+const oldElements = page.children.filter(n =>
+	(n.type === "TEXT" && (n.name.startsWith("Row: ") || n.name.startsWith("Col: "))) ||
+	(n.type === "FRAME" && (n.name === "Component Container" || n.name === "Row Labels" || n.name === "Column Headers"))
+);
+for (const el of oldElements) {
+	el.remove();
+}
+
+// ============================================================================
+// STEP 2: Clone variants and recreate component set with native visualization
+// ============================================================================
+const clonedVariants = [];
+for (const variant of variants) {
+	const clone = variant.clone();
+	page.appendChild(clone);
+	clonedVariants.push(clone);
+}
+
+// Delete the old component set
+componentSet.remove();
+
+// Recreate using figma.combineAsVariants() for native purple dashed frame
+const newComponentSet = figma.combineAsVariants(clonedVariants, page);
+newComponentSet.name = csOriginalName;
+
+// Apply purple dashed border (Figma's native component set styling)
+newComponentSet.strokes = [{
+	type: 'SOLID',
+	color: { r: 151/255, g: 71/255, b: 255/255 }  // Figma's purple: #9747FF
+}];
+newComponentSet.dashPattern = [10, 5];
+newComponentSet.strokeWeight = 1;
+newComponentSet.strokeAlign = "INSIDE";
+
+// ============================================================================
+// STEP 3: Arrange variants in grid pattern inside component set
+// ============================================================================
+const newVariants = newComponentSet.children.filter(n => n.type === "COMPONENT");
+
+for (const variant of newVariants) {
+	const props = parseVariantName(variant.name);
+	const colValue = props[columnProp];
+	const colIdx = columnValues.indexOf(colValue);
+
+	// Find matching row
+	let rowIdx = -1;
+	for (let i = 0; i < rowCombinations.length; i++) {
+		const combo = rowCombinations[i];
+		let match = true;
+		for (const [key, value] of Object.entries(combo)) {
+			if (props[key] !== value) {
+				match = false;
+				break;
+			}
+		}
+		if (match) {
+			rowIdx = i;
+			break;
+		}
+	}
+
+	if (colIdx >= 0 && rowIdx >= 0) {
+		// Calculate cell position
+		const cellX = edgePadding + colIdx * (cellWidth + gap);
+		const cellY = edgePadding + rowIdx * (cellHeight + gap);
+
+		// Center variant within cell
+		const variantX = Math.round(cellX + (cellWidth - variant.width) / 2);
+		const variantY = Math.round(cellY + (cellHeight - variant.height) / 2);
+
+		variant.x = variantX;
+		variant.y = variantY;
+	}
+}
+
+// Resize component set to fit grid
+newComponentSet.resize(csWidth, csHeight);
+
+// ============================================================================
+// STEP 4: Create white container frame with proper structure
+// ============================================================================
+
+// Load font for labels
+await figma.loadFontAsync({ family: "Inter", style: "Regular" });
+await figma.loadFontAsync({ family: "Inter", style: "Semi Bold" });
+
+// Create the main container frame (white background)
+const containerFrame = figma.createFrame();
+containerFrame.name = "Component Container";
+containerFrame.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];  // White
+containerFrame.cornerRadius = 8;
+containerFrame.layoutMode = 'VERTICAL';
+containerFrame.primaryAxisSizingMode = 'AUTO';
+containerFrame.counterAxisSizingMode = 'AUTO';
+containerFrame.paddingTop = CONTAINER_PADDING;
+containerFrame.paddingRight = CONTAINER_PADDING;
+containerFrame.paddingBottom = CONTAINER_PADDING;
+containerFrame.paddingLeft = CONTAINER_PADDING;
+containerFrame.itemSpacing = 24;
+
+// Add title
+const titleText = figma.createText();
+titleText.name = "Title";
+titleText.characters = csOriginalName;
+titleText.fontSize = TITLE_FONT_SIZE;
+titleText.fontName = { family: "Inter", style: "Semi Bold" };
+titleText.fills = [{ type: 'SOLID', color: TITLE_COLOR }];
+// Append to parent FIRST, then set layoutSizing
+containerFrame.appendChild(titleText);
+titleText.layoutSizingHorizontal = 'HUG';
+titleText.layoutSizingVertical = 'HUG';
+
+// Create content row (horizontal: row labels + grid column)
+const contentRow = figma.createFrame();
+contentRow.name = "Content Row";
+contentRow.fills = [];  // Transparent
+contentRow.layoutMode = 'HORIZONTAL';
+contentRow.primaryAxisSizingMode = 'AUTO';
+contentRow.counterAxisSizingMode = 'AUTO';
+contentRow.itemSpacing = LABEL_GAP;
+contentRow.counterAxisAlignItems = 'MIN';  // Align to top
+containerFrame.appendChild(contentRow);
+
+// ============================================================================
+// STEP 5: Create row labels column (left side)
+// ============================================================================
+const rowLabelsFrame = figma.createFrame();
+rowLabelsFrame.name = "Row Labels";
+rowLabelsFrame.fills = [];  // Transparent
+rowLabelsFrame.layoutMode = 'VERTICAL';
+rowLabelsFrame.primaryAxisSizingMode = 'AUTO';
+rowLabelsFrame.counterAxisSizingMode = 'AUTO';
+rowLabelsFrame.counterAxisAlignItems = 'MAX';  // Right-align text
+rowLabelsFrame.itemSpacing = 0;  // No spacing - we'll use fixed heights
+
+// Add spacer for column headers alignment
+// Must account for: column header height + gap + component set's internal edgePadding
+const rowLabelSpacer = figma.createFrame();
+rowLabelSpacer.name = "Spacer";
+rowLabelSpacer.fills = [];
+rowLabelSpacer.resize(10, COLUMN_HEADER_HEIGHT + gap + edgePadding);  // Align with first row inside component set
+rowLabelsFrame.appendChild(rowLabelSpacer);
+// IMPORTANT: Set layoutSizing AFTER appendChild (node must be in auto-layout parent first)
+rowLabelSpacer.layoutSizingVertical = 'FIXED';
+
+// Create row labels - each with VERTICAL layout for direct vertical centering
+// Using VERTICAL layout: primaryAxis = vertical, counterAxis = horizontal
+// So primaryAxisAlignItems = 'CENTER' directly controls vertical centering
+for (let i = 0; i < rowCombinations.length; i++) {
+	const combo = rowCombinations[i];
+	const labelText = rowProps.map(p => combo[p]).join(" / ");
+	const isLastRow = (i === rowCombinations.length - 1);
+
+	// Create a frame to hold the label with VERTICAL layout
+	const rowLabelContainer = figma.createFrame();
+	rowLabelContainer.name = "Row: " + labelText;
+	rowLabelContainer.fills = [];
+	rowLabelContainer.layoutMode = 'VERTICAL';  // VERTICAL so primaryAxis controls Y
+	rowLabelContainer.primaryAxisSizingMode = 'FIXED';  // CRITICAL: Don't hug content, maintain fixed height
+	rowLabelContainer.primaryAxisAlignItems = 'CENTER';  // CENTER = vertically centered within fixed height
+	rowLabelContainer.counterAxisAlignItems = 'MAX';  // MAX = right-aligned horizontally
+
+	// Fixed height = cellHeight only (gap handled separately below)
+	rowLabelContainer.resize(10, cellHeight);
+
+	const label = figma.createText();
+	label.characters = labelText;
+	label.fontSize = LABEL_FONT_SIZE;
+	label.fontName = { family: "Inter", style: "Regular" };
+	label.fills = [{ type: 'SOLID', color: LABEL_COLOR }];
+	label.textAlignHorizontal = 'RIGHT';
+	rowLabelContainer.appendChild(label);
+
+	// Append to parent FIRST, then set layoutSizing properties
+	rowLabelsFrame.appendChild(rowLabelContainer);
+	rowLabelContainer.layoutSizingHorizontal = 'HUG';
+	rowLabelContainer.layoutSizingVertical = 'FIXED';
+
+	// Add gap spacer AFTER the row label (except for the last row)
+	// This separates the gap from the centering calculation entirely
+	if (!isLastRow) {
+		const gapSpacer = figma.createFrame();
+		gapSpacer.name = "Row Gap";
+		gapSpacer.fills = [];
+		gapSpacer.resize(1, gap);
+		rowLabelsFrame.appendChild(gapSpacer);
+		// Plain frames can only use FIXED or FILL (not HUG)
+		gapSpacer.layoutSizingHorizontal = 'FIXED';
+		gapSpacer.layoutSizingVertical = 'FIXED';
+	}
+}
+
+contentRow.appendChild(rowLabelsFrame);
+
+// ============================================================================
+// STEP 6: Create grid column (column headers + component set)
+// ============================================================================
+const gridColumn = figma.createFrame();
+gridColumn.name = "Grid Column";
+gridColumn.fills = [];  // Transparent
+gridColumn.layoutMode = 'VERTICAL';
+gridColumn.primaryAxisSizingMode = 'AUTO';
+gridColumn.counterAxisSizingMode = 'AUTO';
+gridColumn.itemSpacing = gap;
+
+// Create column headers row
+const columnHeadersRow = figma.createFrame();
+columnHeadersRow.name = "Column Headers";
+columnHeadersRow.fills = [];
+columnHeadersRow.layoutMode = 'HORIZONTAL';
+columnHeadersRow.resize(csWidth, COLUMN_HEADER_HEIGHT);
+columnHeadersRow.itemSpacing = 0;  // No spacing - we control widths precisely
+columnHeadersRow.paddingLeft = edgePadding;  // Match component set edge padding
+columnHeadersRow.paddingRight = edgePadding;
+
+// Create column header labels - each with width matching cell + gap
+for (let i = 0; i < columnValues.length; i++) {
+	const colValue = columnValues[i];
+	const isLastCol = (i === columnValues.length - 1);
+
+	const colHeaderContainer = figma.createFrame();
+	colHeaderContainer.name = "Col: " + colValue;
+	colHeaderContainer.fills = [];
+	colHeaderContainer.layoutMode = 'HORIZONTAL';
+	colHeaderContainer.primaryAxisAlignItems = 'CENTER';  // Center horizontally
+	colHeaderContainer.counterAxisAlignItems = 'MAX';  // Align to bottom
+
+	// Set width to match cell + gap (except last column)
+	// Use paddingRight to push the gap to the RIGHT of the centered text area
+	const colWidth = isLastCol ? cellWidth : cellWidth + gap;
+	colHeaderContainer.resize(colWidth, COLUMN_HEADER_HEIGHT);
+	if (!isLastCol) {
+		colHeaderContainer.paddingRight = gap;  // Gap goes right, text centers in cellWidth
+	}
+
+	const label = figma.createText();
+	label.characters = colValue;
+	label.fontSize = LABEL_FONT_SIZE;
+	label.fontName = { family: "Inter", style: "Regular" };
+	label.fills = [{ type: 'SOLID', color: LABEL_COLOR }];
+	label.textAlignHorizontal = 'CENTER';
+	colHeaderContainer.appendChild(label);
+
+	// Append to parent FIRST, then set layoutSizing
+	columnHeadersRow.appendChild(colHeaderContainer);
+	colHeaderContainer.layoutSizingHorizontal = 'FIXED';
+	colHeaderContainer.layoutSizingVertical = 'FILL';
+}
+
+// Append to parent FIRST, then set layoutSizing
+gridColumn.appendChild(columnHeadersRow);
+columnHeadersRow.layoutSizingHorizontal = 'FIXED';
+columnHeadersRow.layoutSizingVertical = 'FIXED';
+
+// Create a wrapper frame to hold the component set (since component sets don't work well in auto-layout)
+const componentSetWrapper = figma.createFrame();
+componentSetWrapper.name = "Component Set Wrapper";
+componentSetWrapper.fills = [];
+componentSetWrapper.resize(csWidth, csHeight);
+
+// Move component set inside wrapper (positioned at 0,0)
+componentSetWrapper.appendChild(newComponentSet);
+newComponentSet.x = 0;
+newComponentSet.y = 0;
+
+// Append to parent FIRST, then set layoutSizing
+gridColumn.appendChild(componentSetWrapper);
+componentSetWrapper.layoutSizingHorizontal = 'FIXED';
+componentSetWrapper.layoutSizingVertical = 'FIXED';
+
+contentRow.appendChild(gridColumn);
+
+// Position container at original location
+containerFrame.x = csOriginalX - CONTAINER_PADDING - 120;  // Account for row labels width
+containerFrame.y = csOriginalY - CONTAINER_PADDING - TITLE_FONT_SIZE - 24 - COLUMN_HEADER_HEIGHT - gap;
+
+// Select and zoom to show result
+figma.currentPage.selection = [containerFrame];
+figma.viewport.scrollAndZoomIntoView([containerFrame]);
+
+return {
+	success: true,
+	message: "Component set arranged with proper container, labels, and alignment",
+	containerId: containerFrame.id,
+	componentSetId: newComponentSet.id,
+	componentSetName: newComponentSet.name,
+	grid: {
+		rows: totalRows,
+		columns: totalCols,
+		cellWidth: cellWidth,
+		cellHeight: cellHeight,
+		gap: gap,
+		columnProperty: columnProp,
+		columnValues: columnValues,
+		rowProperties: rowProps,
+		rowLabels: rowCombinations.map(combo => rowProps.map(p => combo[p]).join(" / "))
+	},
+	componentSetSize: { width: csWidth, height: csHeight },
+	variantCount: newVariants.length,
+	structure: {
+		container: "White frame with title, row labels, column headers, and component set",
+		rowLabels: "Vertically aligned with each row's center",
+		columnHeaders: "Horizontally aligned with each column's center"
+	}
+};
+`;
+
+				const result = await connector.executeCodeViaUI(code, 25000);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to arrange component set");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									...result.result,
+									hint: result.result?.success
+										? "Component set arranged in a white container frame with properly aligned row and column labels. The purple dashed border is visible. Use figma_capture_screenshot to validate the layout."
+										: undefined,
+								},
+							),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "Failed to arrange component set");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(
+								{
+									error:
+										error instanceof Error ? error.message : String(error),
+									hint: "Make sure the Desktop Bridge plugin is running and a component set exists.",
+								},
+							),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,12 @@ import { registerFigmaAPITools } from "./core/figma-tools.js";
 import { registerDesignCodeTools } from "./core/design-code-tools.js";
 import { registerCommentTools } from "./core/comment-tools.js";
 import { registerDesignSystemTools } from "./core/design-system-tools.js";
+import { PluginRelayDO, generatePairingCode } from "./core/cloud-websocket-relay.js";
+import { CloudWebSocketConnector } from "./core/cloud-websocket-connector.js";
+import { registerWriteTools } from "./core/write-tools.js";
+
+// Re-export PluginRelayDO so Cloudflare Workers can bind it as a Durable Object
+export { PluginRelayDO } from "./core/cloud-websocket-relay.js";
 // Note: MCP Apps (Token Browser, Dashboard) are only available in local mode
 // They require Node.js file system APIs for serving HTML that don't work in Cloudflare Workers
 
@@ -880,6 +886,74 @@ export class FigmaConsoleMCPv3 extends McpAgent {
 			},
 		);
 
+		// ================================================================
+		// Cloud Write Relay — Pairing Tool
+		// ================================================================
+		this.server.tool(
+			"figma_pair_plugin",
+			"Pair the Figma Desktop Bridge plugin to this cloud session for write access. Returns a 6-character code the user enters in the plugin's Cloud Mode section.",
+			{},
+			async () => {
+				try {
+					const env = this.env as Env;
+					const code = generatePairingCode();
+
+					// Create a unique DO ID for this relay session
+					const relayDoId = env.PLUGIN_RELAY.newUniqueId().toString();
+
+					// Store pairing code → relay DO ID in KV (5-min TTL, one-time use)
+					await env.OAUTH_TOKENS.put(`pairing:${code}`, relayDoId, {
+						expirationTtl: 300,
+					});
+
+					// Store relay DO ID in this MCP DO's storage for session persistence
+					await this.ctx.storage.put('relayDoId', relayDoId);
+
+					return {
+						content: [{
+							type: "text" as const,
+							text: JSON.stringify({
+								pairingCode: code,
+								expiresIn: "5 minutes",
+								instructions: [
+									"1. Open the Desktop Bridge plugin in Figma Desktop",
+									"2. Click the 'Cloud Mode' toggle in the plugin UI",
+									`3. Enter pairing code: ${code}`,
+									"4. Click 'Connect' — the plugin will connect to the cloud relay",
+									"5. Once paired, write tools (variables, components, nodes) work through the cloud"
+								],
+							}, null, 2),
+						}],
+					};
+				} catch (error) {
+					const errorMessage = error instanceof Error ? error.message : String(error);
+					return {
+						content: [{ type: "text" as const, text: JSON.stringify({ error: errorMessage }) }],
+						isError: true,
+					};
+				}
+			},
+		);
+
+		// ================================================================
+		// Cloud Desktop Connector factory
+		// ================================================================
+		const getCloudDesktopConnector = async (): Promise<any> => {
+			const env = this.env as Env;
+			const relayDoId = await this.ctx.storage.get<string>('relayDoId');
+			if (!relayDoId) {
+				throw new Error('No cloud relay session. Call figma_pair_plugin first to pair the Desktop Bridge plugin.');
+			}
+			const doId = env.PLUGIN_RELAY.idFromString(relayDoId);
+			const stub = env.PLUGIN_RELAY.get(doId);
+			const connector = new CloudWebSocketConnector(stub);
+			await connector.initialize();
+			return connector;
+		};
+
+		// Register all write/manipulation tools via shared function
+		registerWriteTools(this.server, getCloudDesktopConnector);
+
 		// Register Figma API tools (Tools 8-14)
 		// Pass isRemoteMode: true to suppress Desktop Bridge mentions in tool descriptions
 		registerFigmaAPITools(
@@ -890,7 +964,8 @@ export class FigmaConsoleMCPv3 extends McpAgent {
 			() => this.browserManager || null,
 			() => this.ensureInitialized(),
 			undefined, // variablesCache
-			{ isRemoteMode: true }
+			{ isRemoteMode: true },
+			getCloudDesktopConnector,
 		);
 
 		// Register Design-Code Parity & Documentation tools
@@ -899,7 +974,8 @@ export class FigmaConsoleMCPv3 extends McpAgent {
 			async () => await this.getFigmaAPI(),
 			() => this.browserManager?.getCurrentUrl() || null,
 			undefined, // variablesCache
-			{ isRemoteMode: true }
+			{ isRemoteMode: true },
+			getCloudDesktopConnector,
 		);
 
 		// Register Comment tools
@@ -932,11 +1008,53 @@ export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url);
 
+		// Use canonical origin for OAuth redirect URIs so they match the Figma OAuth app config
+		// regardless of whether the request comes via workers.dev or custom domain
+		const oauthOrigin = env.CANONICAL_ORIGIN || url.origin;
+
 		// Redirect /docs to subdomain
 		if (url.pathname === "/docs" || url.pathname.startsWith("/docs/")) {
 			const newPath = url.pathname.replace(/^\/docs\/?/, "/");
 			const redirectUrl = `https://docs.figma-console-mcp.southleft.com${newPath}${url.search}`;
 			return Response.redirect(redirectUrl, 301);
+		}
+
+		// ================================================================
+		// Cloud Write Relay — Plugin WebSocket pairing endpoint
+		// ================================================================
+		if (url.pathname === "/ws/pair") {
+			const code = url.searchParams.get("code");
+			if (!code) {
+				return new Response(JSON.stringify({ error: "Missing pairing code" }), {
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+
+			// Look up pairing code in KV
+			const pairingKey = `pairing:${code.toUpperCase()}`;
+			const relayDoId = await env.OAUTH_TOKENS.get(pairingKey);
+
+			if (!relayDoId) {
+				return new Response(JSON.stringify({ error: "Invalid or expired pairing code" }), {
+					status: 404,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+
+			// Delete used code (one-time use)
+			await env.OAUTH_TOKENS.delete(pairingKey);
+
+			// Forward WebSocket upgrade to the relay DO
+			const doId = env.PLUGIN_RELAY.idFromString(relayDoId);
+			const stub = env.PLUGIN_RELAY.get(doId);
+
+			// Rewrite URL to the relay DO's /ws/connect path
+			const relayUrl = new URL(request.url);
+			relayUrl.pathname = "/ws/connect";
+			const relayRequest = new Request(relayUrl.toString(), request);
+
+			return stub.fetch(relayRequest);
 		}
 
 		// SSE endpoint for remote MCP clients
@@ -1101,6 +1219,71 @@ export default {
 				version: "1.11.6",
 			});
 
+			// ================================================================
+			// Cloud Write Relay — Pairing Tool (stateless /mcp path)
+			// Uses KV keyed by bearer token instead of DO storage
+			// ================================================================
+			statelessServer.tool(
+				"figma_pair_plugin",
+				"Pair the Figma Desktop Bridge plugin to this cloud session for write access. Returns a 6-character code the user enters in the plugin's Cloud Mode section.",
+				{},
+				async () => {
+					try {
+						const code = generatePairingCode();
+						const relayDoId = env.PLUGIN_RELAY.newUniqueId().toString();
+
+						// Store pairing code → relay DO ID in KV (5-min TTL, one-time use)
+						await env.OAUTH_TOKENS.put(`pairing:${code}`, relayDoId, {
+							expirationTtl: 300,
+						});
+
+						// Store relay DO ID keyed by bearer token for session persistence
+						await env.OAUTH_TOKENS.put(`relay:${bearerToken}`, relayDoId, {
+							expirationTtl: 86400, // 24h — matches typical session length
+						});
+
+						return {
+							content: [{
+								type: "text" as const,
+								text: JSON.stringify({
+									pairingCode: code,
+									expiresIn: "5 minutes",
+									instructions: [
+										"1. Open the MCP Bridge plugin in Figma Desktop",
+										"2. Click the '▶ Cloud Mode' toggle in the plugin UI",
+										`3. Enter pairing code: ${code}`,
+										"4. Click 'Connect' — the plugin will connect to the cloud relay",
+										"5. Once paired, write tools (variables, components, nodes) work through the cloud"
+									],
+								}, null, 2),
+							}],
+						};
+					} catch (error) {
+						const errorMessage = error instanceof Error ? error.message : String(error);
+						return {
+							content: [{ type: "text" as const, text: JSON.stringify({ error: errorMessage }) }],
+							isError: true,
+						};
+					}
+				},
+			);
+
+			// Cloud Desktop Connector factory (stateless /mcp path)
+			const getCloudDesktopConnector = async (): Promise<any> => {
+				const relayDoId = await env.OAUTH_TOKENS.get(`relay:${bearerToken}`);
+				if (!relayDoId) {
+					throw new Error('No cloud relay session. Call figma_pair_plugin first to pair the Desktop Bridge plugin.');
+				}
+				const doId = env.PLUGIN_RELAY.idFromString(relayDoId);
+				const stub = env.PLUGIN_RELAY.get(doId);
+				const connector = new CloudWebSocketConnector(stub);
+				await connector.initialize();
+				return connector;
+			};
+
+			// Register all write/manipulation tools via shared function
+			registerWriteTools(statelessServer, getCloudDesktopConnector);
+
 			// Register REST API tools with the authenticated Figma API
 			registerFigmaAPITools(
 				statelessServer,
@@ -1111,6 +1294,7 @@ export default {
 				undefined,  // No ensureInitialized
 				new Map(),  // Fresh variables cache per request
 				{ isRemoteMode: true },
+				getCloudDesktopConnector,
 			);
 
 			registerDesignCodeTools(
@@ -1119,6 +1303,7 @@ export default {
 				() => null,
 				new Map(), // Fresh variables cache per request
 				{ isRemoteMode: true },
+				getCloudDesktopConnector,
 			);
 
 			registerCommentTools(
@@ -1249,7 +1434,7 @@ export default {
 			// Redirect to Figma OAuth
 			const figmaAuthUrl = new URL("https://www.figma.com/oauth");
 			figmaAuthUrl.searchParams.set("client_id", env.FIGMA_OAUTH_CLIENT_ID);
-			figmaAuthUrl.searchParams.set("redirect_uri", `${url.origin}/oauth/callback`);
+			figmaAuthUrl.searchParams.set("redirect_uri", `${oauthOrigin}/oauth/callback`);
 			figmaAuthUrl.searchParams.set("scope", "file_content:read,library_content:read,file_variables:read");
 			figmaAuthUrl.searchParams.set("state", stateToken);
 			figmaAuthUrl.searchParams.set("response_type", "code");
@@ -1480,7 +1665,7 @@ export default {
 				expirationTtl: 600 // 10 minutes
 			});
 
-			const redirectUri = `${url.origin}/oauth/callback`;
+			const redirectUri = `${oauthOrigin}/oauth/callback`;
 
 			const figmaAuthUrl = new URL("https://www.figma.com/oauth");
 			figmaAuthUrl.searchParams.set("client_id", env.FIGMA_OAUTH_CLIENT_ID);
@@ -1546,7 +1731,7 @@ export default {
 				const credentials = btoa(`${env.FIGMA_OAUTH_CLIENT_ID}:${env.FIGMA_OAUTH_CLIENT_SECRET}`);
 
 				const tokenParams = new URLSearchParams({
-					redirect_uri: `${url.origin}/oauth/callback`,
+					redirect_uri: `${oauthOrigin}/oauth/callback`,
 					code,
 					grant_type: "authorization_code"
 				});

--- a/tests/__mocks__/cloudflare-workers.js
+++ b/tests/__mocks__/cloudflare-workers.js
@@ -1,0 +1,14 @@
+/**
+ * Mock for cloudflare:workers module used in Jest tests.
+ * Provides a minimal DurableObject base class so cloud-only
+ * modules can be imported in Node.js test environment.
+ */
+
+class DurableObject {
+  constructor(ctx, env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}
+
+module.exports = { DurableObject };

--- a/tests/cloud-relay.test.ts
+++ b/tests/cloud-relay.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for Cloud Write Relay
+ *
+ * Tests the pairing code generation, CloudWebSocketConnector,
+ * and PluginRelayDO behavior in isolation.
+ */
+
+import { generatePairingCode } from '../src/core/cloud-websocket-relay';
+import { CloudWebSocketConnector } from '../src/core/cloud-websocket-connector';
+
+// ============================================================================
+// Pairing Code Generation
+// ============================================================================
+
+describe('generatePairingCode', () => {
+	it('returns a 6-character string', () => {
+		const code = generatePairingCode();
+		expect(code).toHaveLength(6);
+	});
+
+	it('contains only allowed characters (no 0/O/1/I)', () => {
+		const allowed = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]+$/;
+		for (let i = 0; i < 50; i++) {
+			const code = generatePairingCode();
+			expect(code).toMatch(allowed);
+		}
+	});
+
+	it('generates unique codes', () => {
+		const codes = new Set<string>();
+		for (let i = 0; i < 100; i++) {
+			codes.add(generatePairingCode());
+		}
+		// With 6 chars from 30-char alphabet, collision in 100 is astronomically unlikely
+		expect(codes.size).toBeGreaterThanOrEqual(95);
+	});
+});
+
+// ============================================================================
+// CloudWebSocketConnector
+// ============================================================================
+
+describe('CloudWebSocketConnector', () => {
+	function createMockStub(options: {
+		connected?: boolean;
+		commandResult?: any;
+		commandError?: string;
+	} = {}) {
+		const { connected = true, commandResult, commandError } = options;
+
+		return {
+			fetch: jest.fn(async (input: RequestInfo, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+
+				if (url.includes('/relay/status')) {
+					return new Response(JSON.stringify({ connected }), {
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+
+				if (url.includes('/relay/command')) {
+					if (commandError) {
+						return new Response(JSON.stringify({ error: commandError }), {
+							headers: { 'Content-Type': 'application/json' },
+						});
+					}
+					return new Response(JSON.stringify({ result: commandResult ?? { success: true } }), {
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+
+				return new Response('Not found', { status: 404 });
+			}),
+		};
+	}
+
+	describe('initialize', () => {
+		it('succeeds when plugin is connected', async () => {
+			const stub = createMockStub({ connected: true });
+			const connector = new CloudWebSocketConnector(stub);
+			await expect(connector.initialize()).resolves.toBeUndefined();
+		});
+
+		it('throws when no plugin is connected', async () => {
+			const stub = createMockStub({ connected: false });
+			const connector = new CloudWebSocketConnector(stub);
+			await expect(connector.initialize()).rejects.toThrow('No plugin connected');
+		});
+	});
+
+	describe('getTransportType', () => {
+		it('returns websocket', () => {
+			const stub = createMockStub();
+			const connector = new CloudWebSocketConnector(stub);
+			expect(connector.getTransportType()).toBe('websocket');
+		});
+	});
+
+	describe('command forwarding', () => {
+		it('sends EXECUTE_CODE to relay', async () => {
+			const stub = createMockStub({ commandResult: { output: 'hello' } });
+			const connector = new CloudWebSocketConnector(stub);
+
+			const result = await connector.executeInPluginContext('console.log("hi")');
+			expect(result).toEqual({ output: 'hello' });
+
+			expect(stub.fetch).toHaveBeenCalledWith(
+				'https://relay/relay/command',
+				expect.objectContaining({
+					method: 'POST',
+					body: expect.stringContaining('EXECUTE_CODE'),
+				}),
+			);
+		});
+
+		it('sends UPDATE_VARIABLE to relay', async () => {
+			const stub = createMockStub({ commandResult: { success: true, variable: { id: 'v1' } } });
+			const connector = new CloudWebSocketConnector(stub);
+
+			const result = await connector.updateVariable('v1', 'm1', '#ff0000');
+			expect(result).toEqual({ success: true, variable: { id: 'v1' } });
+
+			const call = stub.fetch.mock.calls.find(
+				(c: any[]) => typeof c[1]?.body === 'string' && c[1].body.includes('UPDATE_VARIABLE')
+			);
+			expect(call).toBeDefined();
+			const body = JSON.parse(call![1].body);
+			expect(body.method).toBe('UPDATE_VARIABLE');
+			expect(body.params.variableId).toBe('v1');
+		});
+
+		it('sends CREATE_VARIABLE with options', async () => {
+			const stub = createMockStub({ commandResult: { success: true } });
+			const connector = new CloudWebSocketConnector(stub);
+
+			await connector.createVariable('my-var', 'col1', 'COLOR', {
+				description: 'A color var',
+				valuesByMode: { m1: '#000' },
+			});
+
+			const call = stub.fetch.mock.calls.find(
+				(c: any[]) => typeof c[1]?.body === 'string' && c[1].body.includes('CREATE_VARIABLE')
+			);
+			const body = JSON.parse(call![1].body);
+			expect(body.params.name).toBe('my-var');
+			expect(body.params.description).toBe('A color var');
+		});
+
+		it('sends DELETE_VARIABLE to relay', async () => {
+			const stub = createMockStub({ commandResult: { success: true } });
+			const connector = new CloudWebSocketConnector(stub);
+			await connector.deleteVariable('v1');
+
+			const call = stub.fetch.mock.calls.find(
+				(c: any[]) => typeof c[1]?.body === 'string' && c[1].body.includes('DELETE_VARIABLE')
+			);
+			expect(call).toBeDefined();
+		});
+
+		it('sends RESIZE_NODE to relay', async () => {
+			const stub = createMockStub({ commandResult: { success: true } });
+			const connector = new CloudWebSocketConnector(stub);
+			await connector.resizeNode('node1', 200, 100, true);
+
+			const call = stub.fetch.mock.calls.find(
+				(c: any[]) => typeof c[1]?.body === 'string' && c[1].body.includes('RESIZE_NODE')
+			);
+			const body = JSON.parse(call![1].body);
+			expect(body.params.nodeId).toBe('node1');
+			expect(body.params.width).toBe(200);
+			expect(body.params.height).toBe(100);
+		});
+
+		it('sends CAPTURE_SCREENSHOT to relay', async () => {
+			const stub = createMockStub({ commandResult: { image: 'base64...' } });
+			const connector = new CloudWebSocketConnector(stub);
+			const result = await connector.captureScreenshot('node1', { format: 'PNG', scale: 2 });
+			expect(result).toEqual({ image: 'base64...' });
+		});
+
+		it('sends INSTANTIATE_COMPONENT with options', async () => {
+			const stub = createMockStub({ commandResult: { success: true, instance: {} } });
+			const connector = new CloudWebSocketConnector(stub);
+			await connector.instantiateComponent('comp-key', {
+				position: { x: 0, y: 0 },
+				parentId: 'frame1',
+			});
+
+			const call = stub.fetch.mock.calls.find(
+				(c: any[]) => typeof c[1]?.body === 'string' && c[1].body.includes('INSTANTIATE_COMPONENT')
+			);
+			const body = JSON.parse(call![1].body);
+			expect(body.params.componentKey).toBe('comp-key');
+			expect(body.params.parentId).toBe('frame1');
+		});
+	});
+
+	describe('error handling', () => {
+		it('throws on relay error response', async () => {
+			const stub = createMockStub({ commandError: 'Plugin disconnected' });
+			const connector = new CloudWebSocketConnector(stub);
+
+			await expect(connector.executeInPluginContext('test'))
+				.rejects.toThrow('Plugin disconnected');
+		});
+
+		it('throws on relay timeout error', async () => {
+			const stub = createMockStub({ commandError: 'Command EXECUTE_CODE timed out after 7000ms' });
+			const connector = new CloudWebSocketConnector(stub);
+
+			await expect(connector.executeInPluginContext('test'))
+				.rejects.toThrow('timed out');
+		});
+	});
+
+	describe('variable operations', () => {
+		it('renameVariable passes through oldName', async () => {
+			const stub = createMockStub({
+				commandResult: { success: true, variable: { oldName: 'old', name: 'new' } },
+			});
+			const connector = new CloudWebSocketConnector(stub);
+			const result = await connector.renameVariable('v1', 'new');
+			expect(result.oldName).toBe('old');
+		});
+
+		it('renameMode passes through oldName', async () => {
+			const stub = createMockStub({
+				commandResult: { success: true, collection: { oldName: 'Light', name: 'Dark' } },
+			});
+			const connector = new CloudWebSocketConnector(stub);
+			const result = await connector.renameMode('col1', 'm1', 'Dark');
+			expect(result.oldName).toBe('Light');
+		});
+
+		it('refreshVariables uses long timeout', async () => {
+			const stub = createMockStub({ commandResult: { success: true } });
+			const connector = new CloudWebSocketConnector(stub);
+			await connector.refreshVariables();
+
+			const call = stub.fetch.mock.calls.find(
+				(c: any[]) => typeof c[1]?.body === 'string' && c[1].body.includes('REFRESH_VARIABLES')
+			);
+			const body = JSON.parse(call![1].body);
+			expect(body.timeoutMs).toBe(300000);
+		});
+	});
+
+	describe('collection operations', () => {
+		it('createVariableCollection passes options', async () => {
+			const stub = createMockStub({ commandResult: { success: true } });
+			const connector = new CloudWebSocketConnector(stub);
+			await connector.createVariableCollection('Colors', {
+				initialModeName: 'Light',
+				additionalModes: ['Dark'],
+			});
+
+			const call = stub.fetch.mock.calls.find(
+				(c: any[]) => typeof c[1]?.body === 'string' && c[1].body.includes('CREATE_VARIABLE_COLLECTION')
+			);
+			const body = JSON.parse(call![1].body);
+			expect(body.params.name).toBe('Colors');
+			expect(body.params.initialModeName).toBe('Light');
+		});
+	});
+
+	describe('node operations', () => {
+		it('setTextContent passes font options', async () => {
+			const stub = createMockStub({ commandResult: { success: true } });
+			const connector = new CloudWebSocketConnector(stub);
+			await connector.setTextContent('node1', 'Hello', { fontSize: 16, fontFamily: 'Inter' });
+
+			const call = stub.fetch.mock.calls.find(
+				(c: any[]) => typeof c[1]?.body === 'string' && c[1].body.includes('SET_TEXT_CONTENT')
+			);
+			const body = JSON.parse(call![1].body);
+			expect(body.params.text).toBe('Hello');
+			expect(body.params.fontSize).toBe(16);
+			expect(body.params.fontFamily).toBe('Inter');
+		});
+
+		it('setNodeStrokes passes strokeWeight', async () => {
+			const stub = createMockStub({ commandResult: { success: true } });
+			const connector = new CloudWebSocketConnector(stub);
+			await connector.setNodeStrokes('node1', [{ type: 'SOLID', color: { r: 1, g: 0, b: 0 } }], 2);
+
+			const call = stub.fetch.mock.calls.find(
+				(c: any[]) => typeof c[1]?.body === 'string' && c[1].body.includes('SET_NODE_STROKES')
+			);
+			const body = JSON.parse(call![1].body);
+			expect(body.params.strokeWeight).toBe(2);
+		});
+
+		it('clearFrameCache is a no-op', () => {
+			const stub = createMockStub();
+			const connector = new CloudWebSocketConnector(stub);
+			expect(() => connector.clearFrameCache()).not.toThrow();
+		});
+	});
+});

--- a/tsconfig.local.json
+++ b/tsconfig.local.json
@@ -9,5 +9,5 @@
 		"sourceMap": true
 	},
 	"include": ["src/local.ts", "src/core/**/*.ts", "src/browser/base.ts", "src/browser/local.ts", "src/apps/**/server.ts"],
-	"exclude": ["src/index.ts", "src/browser/cloudflare.ts", "src/test-browser.ts", "node_modules", "dist"]
+	"exclude": ["src/index.ts", "src/browser/cloudflare.ts", "src/test-browser.ts", "src/core/cloud-websocket-relay.ts", "src/core/cloud-websocket-connector.ts", "node_modules", "dist"]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,6 +31,10 @@
 				}
 			],
 			"tag": "v3"
+		},
+		{
+			"new_sqlite_classes": ["PluginRelayDO"],
+			"tag": "v4"
 		}
 	],
 	"durable_objects": {
@@ -38,6 +42,10 @@
 			{
 				"class_name": "FigmaConsoleMCPv3",
 				"name": "MCP_OBJECT"
+			},
+			{
+				"class_name": "PluginRelayDO",
+				"name": "PLUGIN_RELAY"
 			}
 		]
 	},


### PR DESCRIPTION
## Summary

Enables web-based AI clients (Claude.ai, v0, Replit, Lovable) to **create and modify Figma designs** through a cloud relay, eliminating the "Remote = read-only" limitation.

- **Cloud Write Relay**: Cloudflare Durable Object bridges the Desktop Bridge plugin to the cloud MCP server via WebSocket
- **43 tools in cloud mode**: 1 pairing + 27 write tools + 15 REST API tools (up from 22 read-only)
- **Zero impact to local users**: `src/local.ts` is completely untouched
- **No new dependencies**: Pure additive changes

### Architecture

```
AI Client (Claude.ai/v0) → Cloud MCP (/mcp) → PluginRelayDO (DO) → WebSocket → Desktop Bridge Plugin → Figma API
```

### Key Changes

**New files:**
- `src/core/cloud-websocket-relay.ts` — `PluginRelayDO` Durable Object (hibernation-aware)
- `src/core/cloud-websocket-connector.ts` — `IFigmaConnector` impl via fetch RPC
- `src/core/write-tools.ts` — Shared 27-tool registration function (local + cloud)
- `tests/cloud-relay.test.ts` — 20 tests for relay functionality

**Modified files:**
- `src/index.ts` — `figma_pair_plugin` tool, relay DO routing, `CANONICAL_ORIGIN` for OAuth
- `figma-desktop-bridge/ui.html` — Cloud Mode toggle with pairing code input
- `figma-desktop-bridge/manifest.json` — Name reverted to "Figma Desktop Bridge", cloud domains added
- `wrangler.jsonc` — `PluginRelayDO` binding + v4 migration
- 7 documentation files updated for three-tier model

### User Impact

| User Type | Impact |
|-----------|--------|
| NPX / Local Git users | **None** — `src/local.ts` untouched |
| Remote SSE/MCP users | Gain new tools (opt-in via pairing) |
| Desktop Bridge plugin users | Must re-import manifest for Cloud Mode |

### Three-Tier Model

| Setup | Tools | Write? | Real-time? | Node.js? |
|-------|-------|--------|------------|----------|
| Remote (read-only) | 22 | ❌ | ❌ | ❌ |
| **Remote + Cloud Relay** | **43** | ✅ | ❌ | ❌ |
| Local (NPX/Git) | 57+ | ✅ | ✅ | ✅ |

## Test plan

- [x] All 368 tests pass (`npm test`)
- [x] Local build succeeds (`npm run build:local`)
- [x] Type-check passes (only pre-existing mcp-app.ts errors)
- [x] Cloudflare deploy succeeds (`npx wrangler deploy`)
- [x] End-to-end cloud pairing tested with Claude.ai
- [x] Write operations verified (shapes, variables, screenshots)
- [x] Connection stability verified (hibernation-safe DO patterns)
- [x] Disconnect button fix verified
- [ ] NPX regression test after merge
- [ ] OAuth redirect regression test (CANONICAL_ORIGIN fallback)