### PR TITLE
docs: add Figma PAT scope requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,18 @@ Figma Console MCP connects AI assistants (like Claude) to Figma, enabling:
 1. Go to [Manage personal access tokens](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens) in Figma Help
 2. Follow the steps to **create a new personal access token**
 3. Enter description: `Figma Console MCP`
-4. **Copy the token** — you won't see it again! (starts with `figd_`)
+4. **Set the following scopes** (see [Figma's scope reference](https://developers.figma.com/docs/rest-api/scopes/)):
+
+   | Scope | Required? | What it enables |
+   |-------|-----------|-----------------|
+   | `file_content:read` | **Yes** | Reading file data, nodes, components, styles, and rendering images |
+   | `file_comments:read` | Recommended | Reading comments on files |
+   | `file_comments:write` | Recommended | Posting and deleting comments |
+   | `file_variables:read` | Optional | Reading variables via REST API (Enterprise plans only; the Desktop Bridge plugin reads variables on any plan) |
+
+5. **Copy the token** — you won't see it again! (starts with `figd_`)
+
+> **Note:** Write operations (creating frames, components, editing designs, managing variables) go through the Desktop Bridge plugin, not the REST API, so they don't require additional token scopes.
 
 #### Step 2: Configure Your MCP Client
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -42,7 +42,11 @@ Figma Console MCP uses **Figma's native authentication**:
     - Generated in Figma account settings
     - Stored locally in your MCP client config
     - Never transmitted except to `api.figma.com`
-    - Scoped permissions based on token configuration
+    - **Required scope:** `file_content:read` (file data, nodes, components, styles, images)
+    - **Recommended scopes:** `file_comments:read` and `file_comments:write` (comment operations)
+    - **Optional scope:** `file_variables:read` (REST API variable access, Enterprise plans only)
+    - Design write operations use the Desktop Bridge plugin (WebSocket), not the REST API, so no write scopes beyond comments are needed
+    - See [Figma's scope reference](https://developers.figma.com/docs/rest-api/scopes/) for full details
   </Accordion>
   <Accordion title="OAuth (Remote Mode)" icon="right-to-bracket">
     - Uses Figma's official OAuth 2.0 flow

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -106,10 +106,21 @@ Before starting, verify you have:
 1. Go to [Manage personal access tokens](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens) in Figma Help
 2. Follow the steps to **create a new personal access token**
 3. Enter description: `Figma Console MCP`
-4. Click **"Generate token"**
-5. **Copy the token immediately** — you won't see it again!
+4. **Set the following scopes** (see [Figma's scope reference](https://developers.figma.com/docs/rest-api/scopes/)):
+
+   | Scope | Required? | What it enables |
+   |-------|-----------|-----------------|
+   | `file_content:read` | **Yes** | Reading file data, nodes, components, styles, and rendering images |
+   | `file_comments:read` | Recommended | Reading comments on files |
+   | `file_comments:write` | Recommended | Posting and deleting comments |
+   | `file_variables:read` | Optional | Reading variables via REST API (Enterprise plans only; the Desktop Bridge plugin reads variables on any plan) |
+
+5. Click **"Generate token"**
+6. **Copy the token immediately** — you won't see it again!
 
 > 💡 Your token starts with `figd_` — if it doesn't, something went wrong.
+>
+> **Why so few scopes?** Design creation and variable management go through the Desktop Bridge plugin (WebSocket), not the REST API. The token is only used for REST API reads, so you only need read scopes for the data you want to access.
 
 ### Step 2: Configure Your MCP Client (~3 min)
 
@@ -639,6 +650,9 @@ For reference, the Codex GUI fields map directly to the [NPX JSON configuration]
 |---------|--------------|-----|
 | "Failed to connect to Figma Desktop" | No transport available | Install Desktop Bridge Plugin and run it in your Figma file |
 | "FIGMA_ACCESS_TOKEN not configured" | Missing or wrong token | Check token in config, must start with `figd_` |
+| "Figma API error (403)" on file data | Token missing required scope | Ensure your token has the `file_content:read` scope enabled |
+| "Figma API error (403)" on variables | Enterprise scope required or missing | `file_variables:read` requires an Enterprise plan; use the Desktop Bridge plugin instead for variable access on any plan |
+| "Figma API error (403)" on comments | Token missing comment scopes | Enable `file_comments:read` (and `file_comments:write` for posting) on your token |
 | "Command not found: node" | Node.js not installed | Install Node.js 18+ from nodejs.org |
 | Tools not appearing in MCP client | Config not loaded | Restart your MCP client completely |
 | "Port 9223 already in use" | Another MCP instance or orphaned process | Server auto-falls back to 9224–9232. Orphaned processes are auto-cleaned on startup (v1.14.0+). |


### PR DESCRIPTION
## Summary
- Adds a token scopes table to README.md and docs/setup.md specifying which Figma PAT scopes are needed (`file_content:read`, `file_comments:read`, `file_comments:write`, `file_variables:read`)
- Replaces vague "Scoped permissions based on token configuration" in docs/security.md with the actual scope names and links to Figma's reference
- Adds three new troubleshooting entries for common 403 errors caused by missing token scopes

## Context
The existing docs walk users through creating a personal access token but never mention which scopes to enable. This leads to confusion and 403 errors, especially around variables (Enterprise-only via REST API) and comments.

## Test plan
- [ ] Verify markdown tables render correctly in GitHub and Mintlify
- [ ] Confirm scope names match current Figma developer docs
- [ ] Check that links to Figma's scope reference resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)