### PR TITLE
fix: widen plugin UI, left-align status, add scan toggle

### DIFF
--- a/figma-desktop-bridge/code.js
+++ b/figma-desktop-bridge/code.js
@@ -8,10 +8,13 @@
 // The server compares this against its own version to detect stale cached plugins.
 var PLUGIN_VERSION = '1.14.0';
 
+var UI_WIDTH = 240;
+var UI_HEIGHT = 50;
+
 console.log('🌉 [Desktop Bridge] Plugin loaded (v' + PLUGIN_VERSION + ')');
 
 // Show minimal UI - compact status indicator
-figma.showUI(__html__, { width: 240, height: 50, visible: true, themeColors: true });
+figma.showUI(__html__, { width: UI_WIDTH, height: UI_HEIGHT, visible: true, themeColors: true });
 
 // ============================================================================
 // CONSOLE CAPTURE — Intercept console.* in the QuickJS sandbox and forward
@@ -201,7 +204,7 @@ figma.ui.onmessage = async (msg) => {
   // ============================================================================
   if (msg.type === 'BOOT_LOAD_UI' && msg.html) {
     console.log('🌉 [Desktop Bridge] Bootloader delivered fresh UI (' + msg.html.length + ' bytes), loading...');
-    figma.showUI(msg.html, { width: 240, height: 50, visible: true, themeColors: true });
+    figma.showUI(msg.html, { width: UI_WIDTH, height: UI_HEIGHT, visible: true, themeColors: true });
 
     // Re-send variables data to the fresh UI — the original send went to the
     // bootloader which discarded it. The fresh UI needs it to show "ready" status.
@@ -242,7 +245,7 @@ figma.ui.onmessage = async (msg) => {
   // ============================================================================
   if (msg.type === 'BOOT_FALLBACK') {
     console.log('🌉 [Desktop Bridge] Old server detected on port ' + msg.port + ', using cached UI');
-    figma.showUI(__html__, { width: 240, height: 50, visible: true, themeColors: true });
+    figma.showUI(__html__, { width: UI_WIDTH, height: UI_HEIGHT, visible: true, themeColors: true });
     return;
   }
 
@@ -2118,7 +2121,7 @@ figma.ui.onmessage = async (msg) => {
   // RESIZE_UI - Dynamically resize the plugin window (e.g., Cloud Mode toggle)
   // ============================================================================
   else if (msg.type === 'RESIZE_UI') {
-    figma.ui.resize(msg.width || 240, msg.height || 36);
+    figma.ui.resize(msg.width || UI_WIDTH, msg.height || UI_HEIGHT);
   }
 
   // ============================================================================
@@ -2143,7 +2146,7 @@ figma.ui.onmessage = async (msg) => {
       });
       // Short delay to let the response message be sent before reload
       setTimeout(function() {
-        figma.showUI(__html__, { width: 240, height: 50, visible: true, themeColors: true });
+        figma.showUI(__html__, { width: UI_WIDTH, height: UI_HEIGHT, visible: true, themeColors: true });
       }, 100);
     } catch (error) {
       var errorMsg = error && error.message ? error.message : String(error);

--- a/figma-desktop-bridge/ui-full.html
+++ b/figma-desktop-bridge/ui-full.html
@@ -786,6 +786,8 @@
             testWs.onopen = function() {
               clearTimeout(timeout);
               foundAny = true;
+              // Remove from pending since it's now an active connection
+              pendingSockets = pendingSockets.filter(function(s) { return s !== testWs; });
               activeConnections.push({ port: port, ws: testWs });
               updateCompatState();
               console.log('[MCP Bridge] WebSocket connected to port ' + port + ' (' + activeConnections.length + ' server(s) total)');
@@ -794,6 +796,7 @@
               pending--;
               if (pending <= 0) {
                 isScanning = false;
+                pendingSockets = [];
                 wsReconnectDelay = 500;
                 wsReconnectAttempts = 0;
               }
@@ -808,6 +811,7 @@
               pending--;
               if (pending <= 0) {
                 isScanning = false;
+                pendingSockets = [];
                 // Retry with backoff if no servers found, up to MAX_INITIAL_SCANS
                 if (!foundAny && activeConnections.length === 0) {
                   initialScanAttempts++;
@@ -1015,6 +1019,7 @@
 
       // Expose rescan function — resets counters and scans again
       window.__wsRescan = function() {
+        scanStopped = false; // ensure UI state is consistent if called directly
         isScanning = false;
         initialScanAttempts = 0;
         wsReconnectAttempts = 0;

--- a/figma-desktop-bridge/ui.html
+++ b/figma-desktop-bridge/ui.html
@@ -108,19 +108,22 @@
       msg.textContent = text;
     }
 
-    function toggleScan() {
+    function enterStoppedState(label) {
+      stopped = true;
+      attempts = MAX_ATTEMPTS;
+      activeSockets.forEach(function(ws) {
+        try { ws.close(); } catch(e) {}
+      });
+      activeSockets = [];
+      setError(label || 'Stopped');
       var btn = document.getElementById('scan-btn');
+      btn.innerHTML = '&#x25B6;';
+      btn.title = 'Rescan for MCP server';
+    }
+
+    function toggleScan() {
       if (!stopped) {
-        // Stop scanning -- close all in-flight sockets
-        stopped = true;
-        attempts = MAX_ATTEMPTS;
-        activeSockets.forEach(function(ws) {
-          try { ws.close(); } catch(e) {}
-        });
-        activeSockets = [];
-        setError('Stopped');
-        btn.innerHTML = '&#x25B6;';
-        btn.title = 'Rescan for MCP server';
+        enterStoppedState('Stopped');
       } else {
         // Rescan
         stopped = false;
@@ -278,6 +281,11 @@
             pluginMessage: { type: 'BOOT_FALLBACK', port: result.port }
           }, '*');
         } else if (result && result.ws) {
+          if (result.ws.readyState !== 1) {
+            // Socket was closed between find and use (e.g., user clicked stop)
+            setError('Connection lost');
+            return;
+          }
           setStatus('MCP found (port ' + result.port + ')');
           document.getElementById('scan-btn').className = 'scan-btn hidden';
 
@@ -296,12 +304,7 @@
             setStatus('Retry ' + attempts + '/' + MAX_ATTEMPTS + '…');
             setTimeout(boot, delay);
           } else if (!stopped) {
-            setError('No MCP server found');
-            // Switch to rescan mode
-            var btn = document.getElementById('scan-btn');
-            stopped = true;
-            btn.innerHTML = '&#x25B6;';
-            btn.title = 'Rescan for MCP server';
+            enterStoppedState('No MCP server found');
           }
         }
       });


### PR DESCRIPTION
## Summary
- Widens plugin window from 140px to 240px so the "Figma Desktop Bridge" title is fully visible
- Left-aligns the status badge instead of centering it
- Adds a stop/rescan toggle button outside the badge (right-aligned)
  - While scanning: stop square to cancel connection attempts
  - While stopped or no server found: play triangle to rescan ports 9223-9232
  - Hidden once connected

## Files changed
- `figma-desktop-bridge/code.js` -- updated `showUI` and `resize` width from 140 to 240
- `figma-desktop-bridge/ui.html` -- bootloader: left-align, scan toggle button and logic
- `figma-desktop-bridge/ui-full.html` -- full UI: left-align, scan toggle with `__wsStopScanning` / `__wsRescan`

## Test plan
- [ ] Re-import manifest in Figma Desktop, verify title is fully visible
- [ ] Verify status badge is left-aligned
- [ ] With no MCP server running: stop button appears, click stops scanning, switches to play/rescan
- [ ] Click rescan, verify it scans again
- [ ] Start MCP server, verify button hides once connected
- [ ] Verify Cloud Mode toggle still works at the new width

🤖 Generated with [Claude Code](https://claude.com/claude-code)