### PR TITLE
fix: resolve package root via import.meta.url in ESM context

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -19,6 +19,8 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    // resolve-package-root uses import.meta.url (ESM-only); mock with __dirname for CJS/Jest
+    '/resolve-package-root\\.js$': '<rootDir>/tests/__mocks__/resolve-package-root.js',
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '^cloudflare:workers$': '<rootDir>/tests/__mocks__/cloudflare-workers.js',
   },

--- a/src/core/resolve-package-root.ts
+++ b/src/core/resolve-package-root.ts
@@ -1,0 +1,12 @@
+/**
+ * Resolve the package root directory.
+ *
+ * Uses import.meta.url (ESM) to compute an absolute path to the package root,
+ * independent of process.cwd(). This file is ESM-only; in CJS test contexts
+ * (Jest/ts-jest), it is replaced via moduleNameMapper — see jest.config.cjs.
+ */
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+// dist/core/resolve-package-root.js → ../../ = package root
+export const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');

--- a/src/core/websocket-server.ts
+++ b/src/core/websocket-server.ts
@@ -20,14 +20,14 @@ import type { Server as HttpServer } from 'http';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { createChildLogger } from './logger.js';
+import { PACKAGE_ROOT } from './resolve-package-root.js';
 import type { ConsoleLogEntry } from './types/index.js';
 
-// Read version from package.json
-// Uses __dirname in CJS/Jest context, falls back to process.cwd() in ESM runtime
+// Read version from package.json using the resolved package root.
+// PACKAGE_ROOT uses import.meta.url in ESM (production) and __dirname in CJS (Jest).
 let SERVER_VERSION = '0.0.0';
 try {
-  const base = typeof __dirname !== 'undefined' ? join(__dirname, '..', '..') : process.cwd();
-  SERVER_VERSION = JSON.parse(readFileSync(join(base, 'package.json'), 'utf-8')).version;
+  SERVER_VERSION = JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf-8')).version;
 } catch {
   // Non-critical — version will show as 0.0.0
 }
@@ -38,11 +38,9 @@ try {
  */
 function loadPluginUIContent(): string {
   const candidates = [
-    // ESM runtime: dist/core/ → ../../figma-desktop-bridge/
-    typeof __dirname !== 'undefined'
-      ? join(__dirname, '..', '..', 'figma-desktop-bridge', 'ui-full.html')
-      : join(process.cwd(), 'figma-desktop-bridge', 'ui-full.html'),
-    // Direct from project root
+    // Primary: relative to package root (works in both CJS and ESM)
+    join(PACKAGE_ROOT, 'figma-desktop-bridge', 'ui-full.html'),
+    // Fallback: relative to cwd (development / monorepo setups)
     join(process.cwd(), 'figma-desktop-bridge', 'ui-full.html'),
   ];
 

--- a/tests/__mocks__/resolve-package-root.js
+++ b/tests/__mocks__/resolve-package-root.js
@@ -1,0 +1,10 @@
+/**
+ * CJS mock for src/core/resolve-package-root.ts (Jest).
+ *
+ * The real module uses import.meta.url (ESM-only). In CJS test
+ * context, __dirname is available and resolves correctly.
+ */
+const { join } = require('path');
+
+// tests/__mocks__/ → ../../ = package root
+module.exports = { PACKAGE_ROOT: join(__dirname, '..', '..') };


### PR DESCRIPTION
## Summary

- Fix `SERVER_VERSION` reporting `"0.0.0"` and `loadPluginUIContent()` returning error HTML in ESM runtime (the `npx` production path)
- Extract package root resolution into `resolve-package-root.ts` using `import.meta.url` — matching the existing pattern in `token-browser/server.ts` and `local.ts`
- Add CJS mock for Jest compatibility (following the existing `cloudflare-workers.js` pattern)

## Problem

`websocket-server.ts` uses `typeof __dirname !== 'undefined'` with a `process.cwd()` fallback. Since the package is ESM (`"type": "module"`), `__dirname` is always `undefined`, and `process.cwd()` resolves to the **user's project directory** — not the package directory. This breaks two things:

1. **`SERVER_VERSION` defaults to `"0.0.0"`** — the bootloader plugin requires `serverVersion >= 1.14.0`, so it rejects the server as "legacy" and falls back to `BOOT_FALLBACK`
2. **`loadPluginUIContent()` can't find `ui-full.html`** — returns "Plugin UI not found" error page instead of the full plugin UI

Tests don't catch this because Jest runs via `ts-jest` in CJS mode where `__dirname` is provided by Node.js automatically.

## Approach

Rather than inlining `import.meta.url` directly in `websocket-server.ts` (which would break CJS test imports with a parse error on `import.meta`), extract the resolution into a dedicated ESM module (`resolve-package-root.ts`) and mock it in Jest — following the repo's existing pattern for environment-specific modules (`cloudflare-workers.js`).

This uses `fileURLToPath(import.meta.url)` (the classic ESM polyfill for `__dirname`) rather than the newer `import.meta.dirname` (Node 20.11+) to stay compatible with the current `engines: ">=18.0.0"` requirement. If/when the minimum Node version is bumped to 20.11+, `resolve-package-root.ts` could be simplified to just `import.meta.dirname` — no other changes needed.

**Changes:**

| File | Change |
|------|--------|
| `src/core/resolve-package-root.ts` | New — exports `PACKAGE_ROOT` via `import.meta.url` |
| `src/core/websocket-server.ts` | Import `PACKAGE_ROOT`, remove dead `typeof __dirname` branches |
| `tests/__mocks__/resolve-package-root.js` | New — CJS mock using `__dirname` |
| `jest.config.cjs` | Add `moduleNameMapper` entry (before `.js` strip rule) |

## Verification

```
# ESM end-to-end from /tmp (simulating npx from user's project dir)
$ cd /tmp && node -e "import { PACKAGE_ROOT } from '.../dist/core/resolve-package-root.js'; ..."
CWD: /private/tmp
PACKAGE_ROOT: /Users/.../figma-console-mcp
version: 1.15.1
ui-full exists: true

# Tests: 16/16 suites, 458/458 tests (matches main)
# Build: clean (npm run build:local)
```

## Test plan

- [x] Existing test suite passes (16/16 suites, 458/458 tests — same as main)
- [x] Build succeeds (`npm run build:local`)
- [x] ESM runtime: health endpoint returns `version: "1.15.1"` (not `"0.0.0"`)
- [x] ESM runtime: WebSocket `SERVER_HELLO` returns correct version
- [x] ESM runtime: `GET_PLUGIN_UI` returns full HTML (49,734 chars, not error page)
- [x] ESM runtime from different CWD (`/tmp`): `PACKAGE_ROOT` resolves correctly
- [x] Similar patterns scanned — no other files have this bug

Closes #38
Closes #39