### PR TITLE
feat(plugin): document-root relaunch button for one-click reopen

### DIFF
--- a/figma-desktop-bridge/code.js
+++ b/figma-desktop-bridge/code.js
@@ -6363,6 +6363,19 @@ figma.loadAllPagesAsync().then(function() {
     });
   });
 
+  // Plant a per-file relaunch button on the document root so subsequent
+  // launches of the Bridge in this file are a one-click action from the
+  // design panel (visible when no node is selected). The relaunch data is
+  // persisted with the document — survives close/reopen and syncs across
+  // collaborators. Only takes effect inside this file; Figma's plugin API
+  // does not expose cross-file launch, so the first launch per file is
+  // still user-driven.
+  try {
+    figma.root.setRelaunchData({ open: 'Open Figma Desktop Bridge' });
+  } catch (e) {
+    console.warn('🌉 [Desktop Bridge] Could not set relaunch data on document root:', e);
+  }
+
   console.log('🌉 [Desktop Bridge] Document change, selection, and page listeners registered');
 }).catch(function(err) {
   console.warn('🌉 [Desktop Bridge] Could not register event listeners:', err);

--- a/figma-desktop-bridge/manifest.json
+++ b/figma-desktop-bridge/manifest.json
@@ -9,6 +9,9 @@
   "enablePrivatePluginApi": true,
   "permissions": ["teamlibrary"],
   "documentAccess": "dynamic-page",
+  "relaunchButtons": [
+    { "command": "open", "name": "Open Figma Desktop Bridge", "multipleSelection": false }
+  ],
   "networkAccess": {
     "allowedDomains": [
       "http://localhost",


### PR DESCRIPTION
## Problem

Multi-file Figma workflows — especially when paired with AI agents driving the Bridge — need a reliable way to reopen the Bridge per file. Today, every reopen requires:

`Plugins > Development > Figma Desktop Bridge > Run`

That's three clicks of menu friction every time you switch back to a file where the Bridge was previously running. For agents that need the Bridge alive in the active file to do anything useful, this turns into a constant interrupt.

## Solution

Plant a per-file relaunch button on `figma.root` via `setRelaunchData`, plus a matching `relaunchButtons` entry in the plugin manifest. Once the Bridge has run in a file, the design panel surfaces a one-click **"Open Figma Desktop Bridge"** button when nothing is selected.

The relaunch data is persisted with the document — survives close/reopen, Figma restarts, and syncs across collaborators on the same file.

## Scope (honest)

This only helps **re-opens** in files where the Bridge has already run at least once. The first launch per file is still user-driven.

That gap is structural: Figma's plugin API does not expose any cross-file launch surface (no `relaunchButtons`/`setRelaunchData` usage exists prior to this PR, no Widget surface in this plugin, no cross-file events). I'm deliberately not trying to paper over that limitation.

A broader UI overhaul (settings modal, port override, debug copy, etc.) is **out of scope** here — happy to follow up with a separate PR if that's of interest.

## Testing

Verified end-to-end in a scratch Figma file:

- `setRelaunchData` call succeeds on document root (no thrown error path hit)
- Relaunch button renders in the design panel when no node is selected
- Button persists across close/reopen of the file
- Button persists across full Figma app restart
- Click-to-launch fires the plugin with `figma.command === 'open'`

## Files changed

- `figma-desktop-bridge/code.js` — +13 lines (try/catch around `figma.root.setRelaunchData` inside the existing `loadAllPagesAsync().then(...)` block)
- `figma-desktop-bridge/manifest.json` — +3 lines (top-level `relaunchButtons` array with one `{ command: "open", name: "Open Figma Desktop Bridge" }` entry)

No behavioural changes outside the relaunch surface. The `try/catch` guards against any edge case (e.g. permissions, future API changes) without affecting the rest of the bootstrap.