### PR TITLE
Add Figma Slots API support (Desktop Bridge)

### DIFF
--- a/figma-desktop-bridge/code.js
+++ b/figma-desktop-bridge/code.js
@@ -218,6 +218,85 @@ function hexToFigmaRGB(hex) {
   return { r: r, g: g, b: b, a: a };
 }
 
+// ============================================================================
+// Slot helpers — Figma Slots open beta (SlotNode API)
+// ============================================================================
+
+function serializeSlotsFromNode(rootNode) {
+  var slots = [];
+  if (!rootNode || typeof rootNode.findAllWithCriteria !== 'function') {
+    return slots;
+  }
+
+  var slotNodes = rootNode.findAllWithCriteria({ types: ['SLOT'] });
+  for (var si = 0; si < slotNodes.length; si++) {
+    var slot = slotNodes[si];
+    var slotInfo = {
+      id: slot.id,
+      name: slot.name,
+      type: 'SLOT',
+      width: slot.width,
+      height: slot.height,
+      layoutMode: slot.layoutMode || 'NONE',
+      propertyKey: null,
+      children: []
+    };
+
+    try {
+      if (slot.componentPropertyReferences && slot.componentPropertyReferences.slotContentId) {
+        slotInfo.propertyKey = slot.componentPropertyReferences.slotContentId;
+      }
+    } catch (e) { /* ignore */ }
+
+    try {
+      for (var ci = 0; ci < slot.children.length; ci++) {
+        var ch = slot.children[ci];
+        slotInfo.children.push({ id: ch.id, name: ch.name, type: ch.type });
+      }
+    } catch (e) { /* slot sublayer — skip inaccessible children */ }
+
+    slots.push(slotInfo);
+  }
+
+  return slots;
+}
+
+async function resolveSlotNode(params) {
+  if (params.slotId) {
+    var slotById = await figma.getNodeByIdAsync(params.slotId);
+    if (!slotById) {
+      throw new Error('Slot node not found: ' + params.slotId);
+    }
+    if (slotById.type !== 'SLOT') {
+      throw new Error('Node is not a SLOT. Got: ' + slotById.type);
+    }
+    return slotById;
+  }
+
+  if (params.instanceId && params.slotName) {
+    var instance = await figma.getNodeByIdAsync(params.instanceId);
+    if (!instance) {
+      throw new Error('Instance node not found: ' + params.instanceId);
+    }
+    if (instance.type !== 'INSTANCE') {
+      throw new Error('Node must be an INSTANCE when using instanceId + slotName. Got: ' + instance.type);
+    }
+    if (typeof instance.findAllWithCriteria !== 'function') {
+      throw new Error('Instance does not support slot lookup');
+    }
+    var matches = instance.findAllWithCriteria({ types: ['SLOT'] }).filter(function(n) {
+      return n.name === params.slotName;
+    });
+    if (matches.length === 0) {
+      var available = instance.findAllWithCriteria({ types: ['SLOT'] }).map(function(n) { return n.name; });
+      throw new Error('Slot "' + params.slotName + '" not found on instance. Available slots: ' + (available.length ? available.join(', ') : '(none)'));
+    }
+    return matches[0];
+  }
+
+  throw new Error('Provide slotId OR (instanceId + slotName)');
+}
+
 // Listen for requests from UI (e.g., component data requests, write operations)
 figma.ui.onmessage = async (msg) => {
 
@@ -813,10 +892,22 @@ figma.ui.onmessage = async (msg) => {
           componentPropertyDefinitions: (node.type === 'COMPONENT_SET' || (node.type === 'COMPONENT' && !isVariant))
             ? node.componentPropertyDefinitions
             : undefined,
-          // Get children info (lightweight) — skip unresolvable slot sublayers
+          // Get children info (lightweight) — include SLOT nodes; skip unresolvable slot sublayers
           children: node.children ? node.children.reduce((acc, child) => {
             try {
-              acc.push({ id: child.id, name: child.name, type: child.type });
+              var childInfo = { id: child.id, name: child.name, type: child.type };
+              if (child.type === 'SLOT') {
+                childInfo.isSlot = true;
+                try {
+                  if (child.componentPropertyReferences && child.componentPropertyReferences.slotContentId) {
+                    childInfo.propertyKey = child.componentPropertyReferences.slotContentId;
+                  }
+                } catch (e) { /* ignore */ }
+                try {
+                  childInfo.childCount = child.children ? child.children.length : 0;
+                } catch (e) { /* ignore */ }
+              }
+              acc.push(childInfo);
             } catch (e) { /* slot sublayer or table cell — skip */ }
             return acc;
           }, []) : undefined
@@ -1117,7 +1208,7 @@ figma.ui.onmessage = async (msg) => {
         componentProps: componentProps,
         stateMachine: stateMachine,
         variants: variantDiffs,
-        ai_instruction: 'Use cssMapping to implement interaction states. diffFromDefault shows only what changes per state — apply these as CSS pseudo-class or attribute overrides. componentProps maps to React/Vue component props (BOOLEAN → boolean prop, TEXT → string prop, INSTANCE_SWAP → ReactNode/slot prop).'
+        ai_instruction: 'Use cssMapping to implement interaction states. diffFromDefault shows only what changes per state — apply these as CSS pseudo-class or attribute overrides. componentProps maps to React/Vue component props (BOOLEAN → boolean prop, TEXT → string prop, INSTANCE_SWAP → ReactNode prop, SLOT → children/slot prop — populate via figma_append_to_slot, not setProperties).'
       };
 
       console.log('🌉 [Desktop Bridge] Component set analysis complete. ' + variants.length + ' variants, ' + Object.keys(stateMachine.cssMapping).length + ' CSS mappings');
@@ -2114,14 +2205,22 @@ figma.ui.onmessage = async (msg) => {
         throw new Error('Cannot add properties to variant components. Add to the parent COMPONENT_SET instead.');
       }
 
-      // Build options if preferredValues provided
+      // Build options if preferredValues and/or description provided (SLOT supports both)
       var options = undefined;
-      if (msg.preferredValues) {
-        options = { preferredValues: msg.preferredValues };
+      if (msg.preferredValues || msg.description) {
+        options = {};
+        if (msg.preferredValues) options.preferredValues = msg.preferredValues;
+        if (msg.description) options.description = msg.description;
+      }
+
+      // SLOT and VARIANT properties do not support defaultValue — pass empty string
+      var defaultValue = msg.defaultValue;
+      if (msg.propertyType === 'SLOT' || msg.propertyType === 'VARIANT') {
+        defaultValue = '';
       }
 
       // Use msg.propertyType (not msg.type which is the message type 'ADD_COMPONENT_PROPERTY')
-      var propertyNameWithId = node.addComponentProperty(msg.propertyName, msg.propertyType, msg.defaultValue, options);
+      var propertyNameWithId = node.addComponentProperty(msg.propertyName, msg.propertyType, defaultValue, options);
 
       console.log('🌉 [Desktop Bridge] Property added:', propertyNameWithId);
 
@@ -2217,6 +2316,267 @@ figma.ui.onmessage = async (msg) => {
         requestId: msg.requestId,
         success: false,
         error: errorMsg
+      });
+    }
+  }
+
+  // ============================================================================
+  // SLOT OPERATIONS — Figma Slots open beta (SlotNode API)
+  // ============================================================================
+
+  // CREATE_SLOT — create a SlotNode inside a component via createSlot()
+  else if (msg.type === 'CREATE_SLOT') {
+    try {
+      console.log('🌉 [Desktop Bridge] Creating slot on component:', msg.nodeId);
+
+      var componentNode = await figma.getNodeByIdAsync(msg.nodeId);
+      if (!componentNode) {
+        throw new Error('Node not found: ' + msg.nodeId);
+      }
+      if (componentNode.type !== 'COMPONENT') {
+        throw new Error('Node must be a COMPONENT. Got: ' + componentNode.type + '. Use createSlot on individual variant components before combineAsVariants.');
+      }
+      if (componentNode.parent && componentNode.parent.type === 'COMPONENT_SET') {
+        throw new Error('Cannot create slots on variant components inside a COMPONENT_SET from this tool. Add slots to each variant component before combining, or target a standalone COMPONENT.');
+      }
+      if (typeof componentNode.createSlot !== 'function') {
+        throw new Error('createSlot() is not available. Update Figma Desktop to a version with Slots support (open beta).');
+      }
+
+      var newSlot = componentNode.createSlot();
+      if (msg.name) newSlot.name = msg.name;
+      if (msg.layoutMode && msg.layoutMode !== 'GRID') {
+        newSlot.layoutMode = msg.layoutMode;
+      } else if (msg.layoutMode === 'GRID') {
+        throw new Error('GRID layoutMode is not allowed on slot nodes');
+      }
+      if (msg.width !== undefined && msg.height !== undefined) {
+        newSlot.resize(msg.width, msg.height);
+      }
+
+      var slotPropertyKey = null;
+      try {
+        if (newSlot.componentPropertyReferences && newSlot.componentPropertyReferences.slotContentId) {
+          slotPropertyKey = newSlot.componentPropertyReferences.slotContentId;
+        }
+      } catch (e) { /* ignore */ }
+
+      figma.ui.postMessage({
+        type: 'CREATE_SLOT_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        slot: {
+          id: newSlot.id,
+          name: newSlot.name,
+          type: newSlot.type,
+          propertyKey: slotPropertyKey,
+          width: newSlot.width,
+          height: newSlot.height,
+          layoutMode: newSlot.layoutMode
+        }
+      });
+    } catch (error) {
+      var createSlotError = error && error.message ? error.message : String(error);
+      console.error('🌉 [Desktop Bridge] Create slot error:', createSlotError);
+      figma.ui.postMessage({
+        type: 'CREATE_SLOT_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: createSlotError
+      });
+    }
+  }
+
+  // GET_SLOTS — list SlotNode children on a component or instance
+  else if (msg.type === 'GET_SLOTS') {
+    try {
+      console.log('🌉 [Desktop Bridge] Getting slots for node:', msg.nodeId);
+
+      var targetNode = await figma.getNodeByIdAsync(msg.nodeId);
+      if (!targetNode) {
+        throw new Error('Node not found: ' + msg.nodeId);
+      }
+      if (targetNode.type !== 'COMPONENT' && targetNode.type !== 'INSTANCE' && targetNode.type !== 'COMPONENT_SET') {
+        throw new Error('Node must be a COMPONENT, COMPONENT_SET, or INSTANCE. Got: ' + targetNode.type);
+      }
+
+      var slotsResult = [];
+      if (targetNode.type === 'COMPONENT_SET') {
+        // Aggregate slots from all variant components
+        for (var vi = 0; vi < targetNode.children.length; vi++) {
+          var variant = targetNode.children[vi];
+          if (variant.type !== 'COMPONENT') continue;
+          var variantSlots = serializeSlotsFromNode(variant);
+          for (var vsi = 0; vsi < variantSlots.length; vsi++) {
+            variantSlots[vsi].variantId = variant.id;
+            variantSlots[vsi].variantName = variant.name;
+          }
+          slotsResult = slotsResult.concat(variantSlots);
+        }
+      } else {
+        slotsResult = serializeSlotsFromNode(targetNode);
+      }
+
+      figma.ui.postMessage({
+        type: 'GET_SLOTS_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        data: {
+          nodeId: targetNode.id,
+          nodeType: targetNode.type,
+          slots: slotsResult,
+          count: slotsResult.length
+        }
+      });
+    } catch (error) {
+      var getSlotsError = error && error.message ? error.message : String(error);
+      console.error('🌉 [Desktop Bridge] Get slots error:', getSlotsError);
+      figma.ui.postMessage({
+        type: 'GET_SLOTS_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: getSlotsError
+      });
+    }
+  }
+
+  // APPEND_TO_SLOT — clone or move a node into a slot (instances only for content population)
+  else if (msg.type === 'APPEND_TO_SLOT') {
+    try {
+      console.log('🌉 [Desktop Bridge] Appending to slot');
+
+      var slotNode = await resolveSlotNode(msg);
+      var slotParent = slotNode.parent;
+      if (!slotParent) {
+        throw new Error('Slot has no parent');
+      }
+
+      if (msg.clearExisting) {
+        var existingChildren = [];
+        try {
+          for (var ei = 0; ei < slotNode.children.length; ei++) {
+            existingChildren.push(slotNode.children[ei]);
+          }
+        } catch (e) { /* ignore */ }
+        for (var er = 0; er < existingChildren.length; er++) {
+          existingChildren[er].remove();
+        }
+      }
+
+      var appendedNode;
+      if (msg.sourceNodeId) {
+        var sourceNode = await figma.getNodeByIdAsync(msg.sourceNodeId);
+        if (!sourceNode) {
+          throw new Error('Source node not found: ' + msg.sourceNodeId);
+        }
+        if (msg.clone !== false) {
+          appendedNode = sourceNode.clone();
+        } else {
+          appendedNode = sourceNode;
+        }
+      } else if (msg.nodeType) {
+        var slotProps = msg.properties || {};
+        switch (msg.nodeType) {
+          case 'RECTANGLE':
+            appendedNode = figma.createRectangle();
+            break;
+          case 'ELLIPSE':
+            appendedNode = figma.createEllipse();
+            break;
+          case 'FRAME':
+            appendedNode = figma.createFrame();
+            break;
+          case 'TEXT':
+            appendedNode = figma.createText();
+            await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+            appendedNode.fontName = { family: 'Inter', style: 'Regular' };
+            if (slotProps.text) appendedNode.characters = slotProps.text;
+            break;
+          case 'LINE':
+            appendedNode = figma.createLine();
+            break;
+          case 'POLYGON':
+            appendedNode = figma.createPolygon();
+            break;
+          case 'STAR':
+            appendedNode = figma.createStar();
+            break;
+          case 'VECTOR':
+            appendedNode = figma.createVector();
+            break;
+          default:
+            throw new Error('Unsupported node type for slot content: ' + msg.nodeType);
+        }
+        if (slotProps.name) appendedNode.name = slotProps.name;
+        if (slotProps.width !== undefined && slotProps.height !== undefined) {
+          appendedNode.resize(slotProps.width, slotProps.height);
+        }
+      } else {
+        throw new Error('Provide sourceNodeId (to clone/move into slot) or nodeType (to create new content in slot)');
+      }
+
+      // ComponentNodes cannot be appended directly to slots
+      if (appendedNode.type === 'COMPONENT') {
+        throw new Error('ComponentNodes cannot be appended directly to a slot. Create an instance with createInstance() or clone an existing instance instead.');
+      }
+
+      slotNode.appendChild(appendedNode);
+
+      figma.ui.postMessage({
+        type: 'APPEND_TO_SLOT_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        slot: { id: slotNode.id, name: slotNode.name },
+        appendedNode: {
+          id: appendedNode.id,
+          name: appendedNode.name,
+          type: appendedNode.type,
+          width: appendedNode.width,
+          height: appendedNode.height
+        }
+      });
+    } catch (error) {
+      var appendSlotError = error && error.message ? error.message : String(error);
+      console.error('🌉 [Desktop Bridge] Append to slot error:', appendSlotError);
+      figma.ui.postMessage({
+        type: 'APPEND_TO_SLOT_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: appendSlotError
+      });
+    }
+  }
+
+  // RESET_SLOT — revert instance slot content to component default
+  else if (msg.type === 'RESET_SLOT') {
+    try {
+      console.log('🌉 [Desktop Bridge] Resetting slot');
+
+      var resetSlotNode = await resolveSlotNode(msg);
+      if (typeof resetSlotNode.resetSlot !== 'function') {
+        throw new Error('resetSlot() is not available on this node. Ensure Figma Desktop supports Slots (open beta).');
+      }
+
+      resetSlotNode.resetSlot();
+
+      figma.ui.postMessage({
+        type: 'RESET_SLOT_RESULT',
+        requestId: msg.requestId,
+        success: true,
+        slot: {
+          id: resetSlotNode.id,
+          name: resetSlotNode.name,
+          childCount: resetSlotNode.children ? resetSlotNode.children.length : 0
+        }
+      });
+    } catch (error) {
+      var resetSlotError = error && error.message ? error.message : String(error);
+      console.error('🌉 [Desktop Bridge] Reset slot error:', resetSlotError);
+      figma.ui.postMessage({
+        type: 'RESET_SLOT_RESULT',
+        requestId: msg.requestId,
+        success: false,
+        error: resetSlotError
       });
     }
   }

--- a/figma-desktop-bridge/ui.html
+++ b/figma-desktop-bridge/ui.html
@@ -439,14 +439,39 @@
       }).catch(function(err) { return { success: false, error: err.message || String(err) }; });
     };
 
-    // Add a component property (BOOLEAN, TEXT, INSTANCE_SWAP, VARIANT)
+    // Add a component property (BOOLEAN, TEXT, INSTANCE_SWAP, VARIANT, SLOT)
     // Note: We use 'propertyType' instead of 'type' to avoid collision with message type field
     window.addComponentProperty = (nodeId, propertyName, type, defaultValue, options) => {
       var params = { nodeId: nodeId, propertyName: propertyName, propertyType: type, defaultValue: defaultValue };
       if (options) {
         if (options.preferredValues) params.preferredValues = options.preferredValues;
+        if (options.description) params.description = options.description;
       }
       return window.sendPluginCommand('ADD_COMPONENT_PROPERTY', params)
+        .catch(function(err) { return { success: false, error: err.message || String(err) }; });
+    };
+
+    // ============================================================================
+    // SLOT OPERATIONS
+    // ============================================================================
+
+    window.createSlot = (nodeId, options) => {
+      return window.sendPluginCommand('CREATE_SLOT', Object.assign({ nodeId: nodeId }, options || {}))
+        .catch(function(err) { return { success: false, error: err.message || String(err) }; });
+    };
+
+    window.getSlots = (nodeId) => {
+      return window.sendPluginCommand('GET_SLOTS', { nodeId: nodeId })
+        .catch(function(err) { return { success: false, error: err.message || String(err) }; });
+    };
+
+    window.appendToSlot = (params) => {
+      return window.sendPluginCommand('APPEND_TO_SLOT', params)
+        .catch(function(err) { return { success: false, error: err.message || String(err) }; });
+    };
+
+    window.resetSlot = (params) => {
+      return window.sendPluginCommand('RESET_SLOT', params)
         .catch(function(err) { return { success: false, error: err.message || String(err) }; });
     };
 
@@ -701,6 +726,10 @@
         'ADD_COMPONENT_PROPERTY': function(params) { return window.addComponentProperty(params.nodeId, params.propertyName, params.propertyType, params.defaultValue, params); },
         'EDIT_COMPONENT_PROPERTY': function(params) { return window.editComponentProperty(params.nodeId, params.propertyName, params.newValue); },
         'DELETE_COMPONENT_PROPERTY': function(params) { return window.deleteComponentProperty(params.nodeId, params.propertyName); },
+        'CREATE_SLOT': function(params) { return window.createSlot(params.nodeId, params); },
+        'GET_SLOTS': function(params) { return window.getSlots(params.nodeId); },
+        'APPEND_TO_SLOT': function(params) { return window.appendToSlot(params); },
+        'RESET_SLOT': function(params) { return window.resetSlot(params); },
         'RESIZE_NODE': function(params) { return window.resizeNode(params.nodeId, params.width, params.height, params.withConstraints); },
         'MOVE_NODE': function(params) { return window.moveNode(params.nodeId, params.x, params.y); },
         'SET_NODE_FILLS': function(params) { return window.setNodeFills(params.nodeId, params.fills); },
@@ -1369,6 +1398,18 @@
           break;
         case 'DELETE_COMPONENT_PROPERTY_RESULT':
           handleResult('DELETE_COMPONENT_PROPERTY', null);
+          break;
+        case 'CREATE_SLOT_RESULT':
+          handleResult('CREATE_SLOT', 'slot');
+          break;
+        case 'GET_SLOTS_RESULT':
+          handleResult('GET_SLOTS', null);
+          break;
+        case 'APPEND_TO_SLOT_RESULT':
+          handleResult('APPEND_TO_SLOT', 'appendedNode');
+          break;
+        case 'RESET_SLOT_RESULT':
+          handleResult('RESET_SLOT', 'slot');
           break;
 
         // NEW: Node manipulation operations

--- a/src/core/cloud-websocket-connector.ts
+++ b/src/core/cloud-websocket-connector.ts
@@ -199,6 +199,7 @@ export class CloudWebSocketConnector implements IFigmaConnector {
 	): Promise<any> {
 		const params: any = { nodeId, propertyName, propertyType: type, defaultValue };
 		if (options?.preferredValues) params.preferredValues = options.preferredValues;
+		if (options?.description) params.description = options.description;
 		return this.sendCommand('ADD_COMPONENT_PROPERTY', params);
 	}
 
@@ -221,6 +222,35 @@ export class CloudWebSocketConnector implements IFigmaConnector {
 			if (options.parentId) params.parentId = options.parentId;
 		}
 		return this.sendCommand('INSTANTIATE_COMPONENT', params);
+	}
+
+	// ============================================================================
+	// Slot operations
+	// ============================================================================
+
+	async createSlot(nodeId: string, options?: { name?: string; width?: number; height?: number; layoutMode?: string }): Promise<any> {
+		return this.sendCommand('CREATE_SLOT', { nodeId, ...options });
+	}
+
+	async getSlots(nodeId: string): Promise<any> {
+		return this.sendCommand('GET_SLOTS', { nodeId });
+	}
+
+	async appendToSlot(params: {
+		slotId?: string;
+		instanceId?: string;
+		slotName?: string;
+		sourceNodeId?: string;
+		nodeType?: string;
+		properties?: Record<string, string | number>;
+		clone?: boolean;
+		clearExisting?: boolean;
+	}): Promise<any> {
+		return this.sendCommand('APPEND_TO_SLOT', params);
+	}
+
+	async resetSlot(params: { slotId?: string; instanceId?: string; slotName?: string }): Promise<any> {
+		return this.sendCommand('RESET_SLOT', params);
 	}
 
 	// ============================================================================

--- a/src/core/design-system-manifest.ts
+++ b/src/core/design-system-manifest.ts
@@ -74,7 +74,7 @@ export interface ComponentVariant {
 
 export interface ComponentProperty {
 	name: string;
-	type: 'TEXT' | 'BOOLEAN' | 'INSTANCE_SWAP' | 'VARIANT';
+	type: 'TEXT' | 'BOOLEAN' | 'INSTANCE_SWAP' | 'VARIANT' | 'SLOT';
 	defaultValue?: string | boolean;
 	options?: string[];  // For INSTANCE_SWAP, available component keys
 }

--- a/src/core/figma-connector.ts
+++ b/src/core/figma-connector.ts
@@ -46,6 +46,21 @@ export interface IFigmaConnector {
   deleteComponentProperty(nodeId: string, propertyName: string): Promise<any>;
   instantiateComponent(componentKey: string, options?: any): Promise<any>;
 
+  // Slot operations (Figma Slots open beta)
+  createSlot(nodeId: string, options?: { name?: string; width?: number; height?: number; layoutMode?: string }): Promise<any>;
+  getSlots(nodeId: string): Promise<any>;
+  appendToSlot(params: {
+    slotId?: string;
+    instanceId?: string;
+    slotName?: string;
+    sourceNodeId?: string;
+    nodeType?: string;
+    properties?: Record<string, string | number>;
+    clone?: boolean;
+    clearExisting?: boolean;
+  }): Promise<any>;
+  resetSlot(params: { slotId?: string; instanceId?: string; slotName?: string }): Promise<any>;
+
   // Node manipulation
   resizeNode(nodeId: string, width: number, height: number, withConstraints?: boolean): Promise<any>;
   moveNode(nodeId: string, x: number, y: number): Promise<any>;

--- a/src/core/figma-tools.ts
+++ b/src/core/figma-tools.ts
@@ -3743,7 +3743,7 @@ export function registerFigmaAPITools(
 	// This is the correct way to update TEXT/BOOLEAN/VARIANT properties on component instances
 	server.tool(
 		"figma_set_instance_properties",
-		"Update component properties on a component instance. IMPORTANT: Use this tool instead of trying to edit text nodes directly when working with component instances. Components often expose TEXT, BOOLEAN, INSTANCE_SWAP, and VARIANT properties that control their content. Direct text node editing may fail silently if the component uses properties. This tool handles the #nodeId suffix pattern automatically. Requires Desktop Bridge connection.",
+		"Update component properties on a component instance. IMPORTANT: Use this tool instead of trying to edit text nodes directly when working with component instances. Components often expose TEXT, BOOLEAN, INSTANCE_SWAP, and VARIANT properties that control their content. SLOT properties CANNOT be set here — use figma_append_to_slot to populate slot content. Direct text node editing may fail silently if the component uses properties. This tool handles the #nodeId suffix pattern automatically. Requires Desktop Bridge connection.",
 		{
 			nodeId: z
 				.string()

--- a/src/core/slot-tools.ts
+++ b/src/core/slot-tools.ts
@@ -1,0 +1,368 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { createChildLogger } from "./logger.js";
+
+const logger = createChildLogger({ component: "slot-tools" });
+
+const SLOT_LAYOUT_MODES = ["NONE", "HORIZONTAL", "VERTICAL"] as const;
+const SLOT_CHILD_NODE_TYPES = [
+	"FRAME",
+	"RECTANGLE",
+	"ELLIPSE",
+	"TEXT",
+	"LINE",
+	"POLYGON",
+	"STAR",
+	"VECTOR",
+] as const;
+
+const preferredValueSchema = z.object({
+	type: z.enum(["COMPONENT", "COMPONENT_SET"]).describe("Type of preferred value"),
+	key: z.string().describe("Component or component set key"),
+});
+
+/**
+ * Register MCP tools for Figma Slots (open beta).
+ * Requires Desktop Bridge and a Figma Desktop version with SlotNode API support.
+ */
+export function registerSlotTools(
+	server: McpServer,
+	getDesktopConnector: () => Promise<any>,
+): void {
+	server.tool(
+		"figma_create_slot",
+		`Create a SlotNode inside a component using createSlot(). Automatically creates a linked SLOT component property. Slots are freeform drop zones for instance content — more flexible than INSTANCE_SWAP. Requires a standalone COMPONENT (not a variant inside a COMPONENT_SET). GRID layout is not allowed on slots. Requires Desktop Bridge.`,
+		{
+			nodeId: z
+				.string()
+				.describe("The COMPONENT node ID to add a slot to"),
+			name: z
+				.string()
+				.optional()
+				.describe("Slot layer name (e.g. 'Content', 'Footer')"),
+			width: z
+				.number()
+				.optional()
+				.describe("Initial slot width in pixels"),
+			height: z
+				.number()
+				.optional()
+				.describe("Initial slot height in pixels"),
+			layoutMode: z
+				.enum(SLOT_LAYOUT_MODES)
+				.optional()
+				.describe("Auto-layout mode for the slot (GRID is not supported)"),
+		},
+		async ({ nodeId, name, width, height, layoutMode }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.createSlot(nodeId, {
+					name,
+					width,
+					height,
+					layoutMode,
+				});
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to create slot");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: true,
+								slot: result.slot,
+								hint: "Use figma_get_slots to inspect slots. Populate instance slots with figma_append_to_slot (not figma_set_instance_properties).",
+							}),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "figma_create_slot failed");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								error: error instanceof Error ? error.message : String(error),
+								hint: "Target a standalone COMPONENT. Add slots to variant components before combineAsVariants. Ensure Figma Desktop supports Slots (open beta).",
+							}),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	server.tool(
+		"figma_get_slots",
+		`List SlotNode children on a component, component set, or instance. Returns slot IDs, names, property keys, dimensions, and current child nodes. Use on instances before figma_append_to_slot to discover slot names/IDs.`,
+		{
+			nodeId: z
+				.string()
+				.describe("COMPONENT, COMPONENT_SET, or INSTANCE node ID"),
+		},
+		async ({ nodeId }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const result = await connector.getSlots(nodeId);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to get slots");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(result.data ?? result),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "figma_get_slots failed");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								error: error instanceof Error ? error.message : String(error),
+								hint: "Ensure the node is a component or instance with slots, and Desktop Bridge is connected.",
+							}),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	server.tool(
+		"figma_append_to_slot",
+		`Add content to a slot on a component instance. Clones sourceNodeId into the slot, or creates a new node (nodeType). SLOT content cannot be set via figma_set_instance_properties — use this tool instead. Widgets, stickies, and raw ComponentNodes cannot be appended to slots.`,
+		{
+			slotId: z
+				.string()
+				.optional()
+				.describe("Direct SlotNode ID (from figma_get_slots)"),
+			instanceId: z
+				.string()
+				.optional()
+				.describe("Instance ID — use with slotName when slotId is unknown"),
+			slotName: z
+				.string()
+				.optional()
+				.describe("Slot layer name on the instance (e.g. 'Content')"),
+			sourceNodeId: z
+				.string()
+				.optional()
+				.describe("Node to clone into the slot (default: clone=true)"),
+			nodeType: z
+				.enum(SLOT_CHILD_NODE_TYPES)
+				.optional()
+				.describe("Create a new node in the slot instead of cloning"),
+			properties: z
+				.record(z.string(), z.union([z.string(), z.number()]))
+				.optional()
+				.describe("Properties for created nodes: name, text, width, height"),
+			clone: z
+				.boolean()
+				.optional()
+				.default(true)
+				.describe("When using sourceNodeId, clone the node (default true). Set false to move."),
+			clearExisting: z
+				.boolean()
+				.optional()
+				.default(false)
+				.describe("Remove existing slot children before appending"),
+		},
+		async (args) => {
+			try {
+				if (!args.slotId && !(args.instanceId && args.slotName)) {
+					throw new Error("Provide slotId OR (instanceId + slotName)");
+				}
+				if (!args.sourceNodeId && !args.nodeType) {
+					throw new Error("Provide sourceNodeId (clone into slot) or nodeType (create new content)");
+				}
+
+				const connector = await getDesktopConnector();
+				const result = await connector.appendToSlot(args);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to append to slot");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: true,
+								slot: result.slot,
+								appendedNode: result.appendedNode,
+								hint: "Use figma_capture_screenshot to verify slot content visually.",
+							}),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "figma_append_to_slot failed");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								error: error instanceof Error ? error.message : String(error),
+								hints: [
+									"Use figma_get_slots on the instance to find slot IDs/names",
+									"Clone instances or frames — not raw ComponentNodes",
+									"SLOT properties cannot be set via figma_set_instance_properties",
+								],
+							}),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	server.tool(
+		"figma_reset_slot",
+		`Reset a slot on a component instance to its default (empty) state from the main component. Uses SlotNode.resetSlot().`,
+		{
+			slotId: z
+				.string()
+				.optional()
+				.describe("Direct SlotNode ID"),
+			instanceId: z
+				.string()
+				.optional()
+				.describe("Instance ID — use with slotName when slotId is unknown"),
+			slotName: z
+				.string()
+				.optional()
+				.describe("Slot layer name on the instance"),
+		},
+		async ({ slotId, instanceId, slotName }) => {
+			try {
+				if (!slotId && !(instanceId && slotName)) {
+					throw new Error("Provide slotId OR (instanceId + slotName)");
+				}
+
+				const connector = await getDesktopConnector();
+				const result = await connector.resetSlot({ slotId, instanceId, slotName });
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to reset slot");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: true,
+								slot: result.slot,
+							}),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "figma_reset_slot failed");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								error: error instanceof Error ? error.message : String(error),
+							}),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+
+	server.tool(
+		"figma_add_slot_property",
+		`Manually add a SLOT component property and bind it to an existing frame (alternative to figma_create_slot). The frame must be a direct child of the component, must not use GRID layout, and must not be nested inside another slot. Supports description and preferredValues.`,
+		{
+			nodeId: z.string().describe("COMPONENT or COMPONENT_SET node ID"),
+			propertyName: z.string().describe("Slot property name (e.g. 'Content')"),
+			frameNodeId: z
+				.string()
+				.describe("Frame node ID to bind as the slot content area"),
+			description: z
+				.string()
+				.optional()
+				.describe("Slot property description (SLOT-only)"),
+			preferredValues: z
+				.array(preferredValueSchema)
+				.optional()
+				.describe("Preferred components for slot content (SLOT-only)"),
+		},
+		async ({ nodeId, propertyName, frameNodeId, description, preferredValues }) => {
+			try {
+				const connector = await getDesktopConnector();
+				const code = `
+const component = await figma.getNodeByIdAsync(${JSON.stringify(nodeId)});
+if (!component || (component.type !== 'COMPONENT' && component.type !== 'COMPONENT_SET')) {
+  throw new Error('Node must be COMPONENT or COMPONENT_SET');
+}
+const frame = await figma.getNodeByIdAsync(${JSON.stringify(frameNodeId)});
+if (!frame || frame.type !== 'FRAME') {
+  throw new Error('frameNodeId must be a FRAME node');
+}
+if (frame.parent !== component) {
+  throw new Error('Frame must be a direct child of the component');
+}
+if (frame.layoutMode === 'GRID') {
+  throw new Error('GRID layoutMode is not allowed on slot frames');
+}
+const options = {};
+${description ? `options.description = ${JSON.stringify(description)};` : ""}
+${preferredValues ? `options.preferredValues = ${JSON.stringify(preferredValues)};` : ""}
+const propKey = component.addComponentProperty(${JSON.stringify(propertyName)}, 'SLOT', '', Object.keys(options).length ? options : undefined);
+frame.componentPropertyReferences = { slotContentId: propKey };
+return { propertyKey: propKey, frameId: frame.id, frameName: frame.name };
+`;
+				const result = await connector.executeCodeViaUI(code, 10000);
+
+				if (!result.success) {
+					throw new Error(result.error || "Failed to add slot property");
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								success: true,
+								result: result.result,
+								hint: "Prefer figma_create_slot() for new slots — it creates the SlotNode and property automatically.",
+							}),
+						},
+					],
+				};
+			} catch (error) {
+				logger.error({ error }, "figma_add_slot_property failed");
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify({
+								error: error instanceof Error ? error.message : String(error),
+							}),
+						},
+					],
+					isError: true,
+				};
+			}
+		},
+	);
+}

--- a/src/core/websocket-connector.ts
+++ b/src/core/websocket-connector.ts
@@ -205,6 +205,7 @@ export class WebSocketConnector implements IFigmaConnector {
   ): Promise<any> {
     const params: any = { nodeId, propertyName, propertyType: type, defaultValue };
     if (options?.preferredValues) params.preferredValues = options.preferredValues;
+    if (options?.description) params.description = options.description;
     return this.wsServer.sendCommand('ADD_COMPONENT_PROPERTY', params);
   }
 
@@ -227,6 +228,35 @@ export class WebSocketConnector implements IFigmaConnector {
       if (options.parentId) params.parentId = options.parentId;
     }
     return this.wsServer.sendCommand('INSTANTIATE_COMPONENT', params);
+  }
+
+  // ============================================================================
+  // Slot operations
+  // ============================================================================
+
+  async createSlot(nodeId: string, options?: { name?: string; width?: number; height?: number; layoutMode?: string }): Promise<any> {
+    return this.wsServer.sendCommand('CREATE_SLOT', { nodeId, ...options });
+  }
+
+  async getSlots(nodeId: string): Promise<any> {
+    return this.wsServer.sendCommand('GET_SLOTS', { nodeId });
+  }
+
+  async appendToSlot(params: {
+    slotId?: string;
+    instanceId?: string;
+    slotName?: string;
+    sourceNodeId?: string;
+    nodeType?: string;
+    properties?: Record<string, string | number>;
+    clone?: boolean;
+    clearExisting?: boolean;
+  }): Promise<any> {
+    return this.wsServer.sendCommand('APPEND_TO_SLOT', params);
+  }
+
+  async resetSlot(params: { slotId?: string; instanceId?: string; slotName?: string }): Promise<any> {
+    return this.wsServer.sendCommand('RESET_SLOT', params);
   }
 
   // ============================================================================

--- a/src/core/write-tools.ts
+++ b/src/core/write-tools.ts
@@ -1257,33 +1257,57 @@ After instantiating components, use figma_take_screenshot to verify the result l
 	// Tool: Add Component Property
 	server.tool(
 		"figma_add_component_property",
-		"Add a new component property to a component or component set. Properties enable dynamic content and behavior in component instances. Supported types: BOOLEAN (toggle), TEXT (string), INSTANCE_SWAP (component swap), VARIANT (variant selection).",
+		"Add a new component property to a component or component set. Properties enable dynamic content and behavior in component instances. Supported types: BOOLEAN (toggle), TEXT (string), INSTANCE_SWAP (component swap), VARIANT (variant selection), SLOT (freeform slot — prefer figma_create_slot for new slots).",
 		{
 			nodeId: z.string().describe("The component or component set node ID"),
 			propertyName: z
 				.string()
 				.describe(
-					"Name for the new property (e.g., 'Show Icon', 'Button Label')",
+					"Name for the new property (e.g., 'Show Icon', 'Button Label', 'Content')",
 				),
 			type: z
-				.enum(["BOOLEAN", "TEXT", "INSTANCE_SWAP", "VARIANT"])
+				.enum(["BOOLEAN", "TEXT", "INSTANCE_SWAP", "VARIANT", "SLOT"])
 				.describe(
-					"Property type: BOOLEAN for toggles, TEXT for strings, INSTANCE_SWAP for component swaps, VARIANT for variant selection",
+					"Property type: BOOLEAN for toggles, TEXT for strings, INSTANCE_SWAP for component swaps, VARIANT for variant selection, SLOT for freeform slot areas",
 				),
 			defaultValue: z
 				.union([z.string(), z.number(), z.boolean()])
+				.optional()
 				.describe(
-					"Default value for the property. BOOLEAN: true/false, TEXT: string, INSTANCE_SWAP: component key, VARIANT: variant value",
+					"Default value. Required for BOOLEAN/TEXT/INSTANCE_SWAP. Omit for VARIANT/SLOT.",
 				),
+			description: z
+				.string()
+				.optional()
+				.describe("Property description (SLOT properties only)"),
+			preferredValues: z
+				.array(
+					z.object({
+						type: z.enum(["COMPONENT", "COMPONENT_SET"]),
+						key: z.string(),
+					}),
+				)
+				.optional()
+				.describe("Preferred components (INSTANCE_SWAP and SLOT only)"),
 		},
-		async ({ nodeId, propertyName, type, defaultValue }) => {
+		async ({ nodeId, propertyName, type, defaultValue, description, preferredValues }) => {
 			try {
 				const connector = await getDesktopConnector();
+				const options: Record<string, unknown> = {};
+				if (description) options.description = description;
+				if (preferredValues) options.preferredValues = preferredValues;
+
+				const resolvedDefault =
+					type === "SLOT" || type === "VARIANT"
+						? ""
+						: defaultValue ?? (type === "BOOLEAN" ? false : "");
+
 				const result = await connector.addComponentProperty(
 					nodeId,
 					propertyName,
 					type,
-					defaultValue,
+					resolvedDefault,
+					Object.keys(options).length > 0 ? options : undefined,
 				);
 
 				if (!result.success) {
@@ -1408,7 +1432,7 @@ After instantiating components, use figma_take_screenshot to verify the result l
 	// Tool: Delete Component Property
 	server.tool(
 		"figma_delete_component_property",
-		"Delete a component property. Only works with BOOLEAN, TEXT, and INSTANCE_SWAP properties (not VARIANT). This is a destructive operation.",
+		"Delete a component property. Works with BOOLEAN, TEXT, INSTANCE_SWAP, and SLOT properties (not VARIANT). This is a destructive operation.",
 		{
 			nodeId: z.string().describe("The component or component set node ID"),
 			propertyName: z
@@ -1452,7 +1476,7 @@ After instantiating components, use figma_take_screenshot to verify the result l
 								{
 									error:
 										error instanceof Error ? error.message : String(error),
-									hint: "Cannot delete VARIANT properties. Only BOOLEAN, TEXT, and INSTANCE_SWAP can be deleted.",
+									hint: "Cannot delete VARIANT properties. BOOLEAN, TEXT, INSTANCE_SWAP, and SLOT can be deleted.",
 								},
 							),
 						},

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { registerWriteTools } from "./core/write-tools.js";
 import { registerTokensTools } from "./core/tokens-tools.js";
 import { registerFigJamTools } from "./core/figjam-tools.js";
 import { registerSlidesTools } from "./core/slides-tools.js";
+import { registerSlotTools } from "./core/slot-tools.js";
 
 // Re-export PluginRelayDO so Cloudflare Workers can bind it as a Durable Object
 export { PluginRelayDO } from "./core/cloud-websocket-relay.js";
@@ -1010,6 +1011,8 @@ export class FigmaConsoleMCPv3 extends McpAgent {
 		// Register Figma Slides tools (slide management, transitions, content)
 		registerSlidesTools(this.server, getCloudDesktopConnector);
 
+		registerSlotTools(this.server, getCloudDesktopConnector);
+
 		// Register Figma API tools (Tools 8-14)
 		// Pass isRemoteMode: true to suppress Desktop Bridge mentions in tool descriptions
 		registerFigmaAPITools(
@@ -1469,6 +1472,8 @@ export default {
 
 			// Register Figma Slides tools
 			registerSlidesTools(statelessServer, getCloudDesktopConnector);
+
+			registerSlotTools(statelessServer, getCloudDesktopConnector);
 
 			// Register REST API tools with the authenticated Figma API
 			registerFigmaAPITools(

--- a/src/local.ts
+++ b/src/local.ts
@@ -63,6 +63,7 @@ import { registerTokenBrowserApp } from "./apps/token-browser/server.js";
 import { registerDesignSystemDashboardApp } from "./apps/design-system-dashboard/server.js";
 import { registerFigJamTools } from "./core/figjam-tools.js";
 import { registerSlidesTools } from "./core/slides-tools.js";
+import { registerSlotTools } from "./core/slot-tools.js";
 
 const logger = createChildLogger({ component: "local-server" });
 
@@ -2962,6 +2963,11 @@ Without libraryFileKey/libraryFileUrl, searches the currently open file (local c
 
 		// Register Figma Slides tools (slide management, transitions, content)
 		registerSlidesTools(
+			this.server,
+			() => this.getDesktopConnector(),
+		);
+
+		registerSlotTools(
 			this.server,
 			() => this.getDesktopConnector(),
 		);

--- a/tests/slot-tools.test.ts
+++ b/tests/slot-tools.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Slot Tools Tests
+ *
+ * Unit tests for Figma Slots MCP tools.
+ */
+
+import { registerSlotTools } from "../src/core/slot-tools";
+
+interface RegisteredTool {
+	name: string;
+	description: string;
+	schema: Record<string, unknown>;
+	handler: (args: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+}
+
+function createMockServer() {
+	const tools: Record<string, RegisteredTool> = {};
+	return {
+		tool: jest.fn(
+			(name: string, description: string, schema: Record<string, unknown>, handler: RegisteredTool["handler"]) => {
+				tools[name] = { name, description, schema, handler };
+			},
+		),
+		_tools: tools,
+		_getTool(name: string): RegisteredTool {
+			return tools[name];
+		},
+	};
+}
+
+function createMockConnector(overrides: Record<string, jest.Mock> = {}) {
+	return {
+		createSlot: jest.fn().mockResolvedValue({
+			success: true,
+			slot: {
+				id: "1:10",
+				name: "Content",
+				type: "SLOT",
+				propertyKey: "Content#1:10",
+				width: 320,
+				height: 200,
+				layoutMode: "VERTICAL",
+			},
+		}),
+		getSlots: jest.fn().mockResolvedValue({
+			success: true,
+			data: {
+				nodeId: "1:2",
+				nodeType: "INSTANCE",
+				count: 1,
+				slots: [
+					{
+						id: "1:10",
+						name: "Content",
+						type: "SLOT",
+						propertyKey: "Content#1:10",
+						children: [],
+					},
+				],
+			},
+		}),
+		appendToSlot: jest.fn().mockResolvedValue({
+			success: true,
+			slot: { id: "1:10", name: "Content" },
+			appendedNode: { id: "1:11", name: "Button", type: "FRAME" },
+		}),
+		resetSlot: jest.fn().mockResolvedValue({
+			success: true,
+			slot: { id: "1:10", name: "Content", childCount: 0 },
+		}),
+		executeCodeViaUI: jest.fn().mockResolvedValue({
+			success: true,
+			result: { propertyKey: "Content#1:10", frameId: "1:5", frameName: "Content" },
+		}),
+		...overrides,
+	};
+}
+
+describe("registerSlotTools", () => {
+	test("registers all five slot tools", () => {
+		const server = createMockServer();
+		registerSlotTools(server as never, async () => createMockConnector());
+
+		expect(Object.keys(server._tools).sort()).toEqual([
+			"figma_add_slot_property",
+			"figma_append_to_slot",
+			"figma_create_slot",
+			"figma_get_slots",
+			"figma_reset_slot",
+		]);
+	});
+
+	test("figma_create_slot calls connector.createSlot", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		const result = await server._getTool("figma_create_slot").handler({
+			nodeId: "1:2",
+			name: "Content",
+			width: 320,
+			height: 200,
+			layoutMode: "VERTICAL",
+		});
+
+		expect(connector.createSlot).toHaveBeenCalledWith("1:2", {
+			name: "Content",
+			width: 320,
+			height: 200,
+			layoutMode: "VERTICAL",
+		});
+		expect(result.isError).toBeUndefined();
+		const payload = JSON.parse(result.content[0].text);
+		expect(payload.success).toBe(true);
+		expect(payload.slot.name).toBe("Content");
+	});
+
+	test("figma_get_slots returns slot list", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		const result = await server._getTool("figma_get_slots").handler({ nodeId: "1:2" });
+		expect(connector.getSlots).toHaveBeenCalledWith("1:2");
+		const payload = JSON.parse(result.content[0].text);
+		expect(payload.count).toBe(1);
+		expect(payload.slots[0].name).toBe("Content");
+	});
+
+	test("figma_append_to_slot requires slot target and content source", async () => {
+		const server = createMockServer();
+		registerSlotTools(server as never, async () => createMockConnector());
+
+		const missingTarget = await server._getTool("figma_append_to_slot").handler({
+			sourceNodeId: "1:99",
+		});
+		expect(missingTarget.isError).toBe(true);
+
+		const missingSource = await server._getTool("figma_append_to_slot").handler({
+			slotId: "1:10",
+		});
+		expect(missingSource.isError).toBe(true);
+	});
+
+	test("figma_append_to_slot clones into slot by slotId", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		const result = await server._getTool("figma_append_to_slot").handler({
+			slotId: "1:10",
+			sourceNodeId: "1:99",
+			clearExisting: true,
+		});
+
+		expect(connector.appendToSlot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				slotId: "1:10",
+				sourceNodeId: "1:99",
+				clearExisting: true,
+			}),
+		);
+		expect(result.isError).toBeUndefined();
+	});
+
+	test("figma_reset_slot resolves by instanceId + slotName", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		await server._getTool("figma_reset_slot").handler({
+			instanceId: "1:2",
+			slotName: "Content",
+		});
+
+		expect(connector.resetSlot).toHaveBeenCalledWith({
+			instanceId: "1:2",
+			slotName: "Content",
+		});
+	});
+
+	test("figma_add_slot_property executes binding code", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		const result = await server._getTool("figma_add_slot_property").handler({
+			nodeId: "1:2",
+			propertyName: "Content",
+			frameNodeId: "1:5",
+			description: "Main content area",
+		});
+
+		expect(connector.executeCodeViaUI).toHaveBeenCalled();
+		const payload = JSON.parse(result.content[0].text);
+		expect(payload.success).toBe(true);
+		expect(payload.result.propertyKey).toBe("Content#1:10");
+	});
+});
+
+describe("WebSocket slot commands", () => {
+	test("connector exposes slot methods", async () => {
+		const { WebSocketConnector } = await import("../src/core/websocket-connector");
+		const mockServer = {
+			isClientConnected: () => false,
+			sendCommand: jest.fn().mockResolvedValue({ success: true }),
+		};
+		const connector = new WebSocketConnector(mockServer as never);
+
+		await connector.createSlot("1:2", { name: "Content" });
+		expect(mockServer.sendCommand).toHaveBeenCalledWith("CREATE_SLOT", {
+			nodeId: "1:2",
+			name: "Content",
+		});
+
+		await connector.getSlots("1:2");
+		expect(mockServer.sendCommand).toHaveBeenCalledWith("GET_SLOTS", { nodeId: "1:2" });
+
+		await connector.appendToSlot({ slotId: "1:10", sourceNodeId: "1:99" });
+		expect(mockServer.sendCommand).toHaveBeenCalledWith("APPEND_TO_SLOT", {
+			slotId: "1:10",
+			sourceNodeId: "1:99",
+		});
+
+		await connector.resetSlot({ slotId: "1:10" });
+		expect(mockServer.sendCommand).toHaveBeenCalledWith("RESET_SLOT", { slotId: "1:10" });
+	});
+});

--- a/tests/websocket-bridge.test.ts
+++ b/tests/websocket-bridge.test.ts
@@ -1002,6 +1002,7 @@ describe('IFigmaConnector interface compliance', () => {
       'deleteVariableCollection', 'getComponentFromPluginUI',
       'getLocalComponents', 'setNodeDescription', 'addComponentProperty',
       'editComponentProperty', 'deleteComponentProperty',
+      'createSlot', 'getSlots', 'appendToSlot', 'resetSlot',
       'instantiateComponent', 'resizeNode', 'moveNode',
       'setNodeFills', 'setNodeStrokes', 'setNodeOpacity',
       'setNodeCornerRadius', 'cloneNode', 'deleteNode',


### PR DESCRIPTION
## Summary
- Adds MCP tools for Figma Slots (open beta): create, list, populate, reset, and manual SLOT property binding
- Extends Desktop Bridge with `CREATE_SLOT`, `GET_SLOTS`, `APPEND_TO_SLOT`, and `RESET_SLOT` commands
- Updates component property tools to support `SLOT` type and documents that slot content must use `figma_append_to_slot` (not `figma_set_instance_properties`)

Closes #29