### PR TITLE
feat(deep): unlimited depth and per-request timeout

### DIFF
--- a/figma-desktop-bridge/code.js
+++ b/figma-desktop-bridge/code.js
@@ -1222,7 +1222,9 @@ figma.ui.onmessage = async (msg) => {
   // ============================================================================
   else if (msg.type === 'DEEP_GET_COMPONENT') {
     try {
-      var maxDepth = msg.depth || 10;
+      var maxDepth = msg.depth;
+      if (maxDepth === undefined || maxDepth === null) maxDepth = 10;
+      if (maxDepth <= 0) maxDepth = Infinity; // 0 or negative = unlimited depth
       console.log('🌉 [Desktop Bridge] Deep component fetch: ' + msg.nodeId + ' (depth: ' + maxDepth + ')');
 
       var rootNode = await figma.getNodeByIdAsync(msg.nodeId);
@@ -1452,7 +1454,7 @@ figma.ui.onmessage = async (msg) => {
 
       var result = walkNode(rootNode, 0);
       result._variableMapSize = Object.keys(varNameMap).length;
-      result._maxDepthUsed = maxDepth;
+      result._maxDepthUsed = (maxDepth === Infinity) ? 'unlimited' : maxDepth;
 
       var resultJson = JSON.stringify(result);
       console.log('🌉 [Desktop Bridge] Deep component data: ' + Math.round(resultJson.length / 1024) + 'KB, vars resolved: ' + Object.keys(varNameMap).length);

--- a/figma-desktop-bridge/ui.html
+++ b/figma-desktop-bridge/ui.html
@@ -962,8 +962,8 @@
     window.deepGetComponent = (nodeId, depth) => {
       return window.sendPluginCommand('DEEP_GET_COMPONENT', {
         nodeId: nodeId,
-        depth: depth || 10
-      }, 30000)
+        depth: (depth === undefined || depth === null) ? 10 : depth
+      }, (typeof depth === 'number' && depth <= 0) ? 120000 : 30000)
         .catch(function(err) { return { success: false, error: err.message || String(err) }; });
     };
 

--- a/src/core/deep-component-tools.ts
+++ b/src/core/deep-component-tools.ts
@@ -30,15 +30,18 @@ export function registerDeepComponentTools(
 			depth: z.preprocess(
 				(v) => (typeof v === "string" ? Number(v) : v),
 				z.number().optional().default(10),
-			).describe("Maximum tree depth to traverse (default: 10, max: 20). Use higher values for deeply nested components."),
+			).describe("Maximum tree depth to traverse (default: 10). Pass 0 (or a negative value) for UNLIMITED depth — traverses the entire subtree. Unlimited/large results can be big; target a specific child node if the payload is unwieldy."),
 		},
 		async ({ nodeId, depth = 10 }) => {
 			try {
-				const clampedDepth = Math.min(Math.max(depth, 1), 20);
-				logger.info({ nodeId, depth: clampedDepth }, "Deep component extraction");
+				// depth <= 0 => unlimited (no clamp); positive values pass through as-is.
+				const unlimited = depth <= 0;
+				const effectiveDepth = unlimited ? 0 : Math.max(depth, 1);
+				const depthLabel: number | string = unlimited ? "unlimited" : effectiveDepth;
+				logger.info({ nodeId, depth: depthLabel }, "Deep component extraction");
 
 				const connector = await getDesktopConnector();
-				const result = await connector.deepGetComponent(nodeId, clampedDepth);
+				const result = await connector.deepGetComponent(nodeId, effectiveDepth);
 
 				if (!result || (result.success === false)) {
 					throw new Error(result?.error || "Failed to extract component");
@@ -55,11 +58,11 @@ export function registerDeepComponentTools(
 					component: data,
 					metadata: {
 						purpose: "deep_component_development",
-						treeDepth: clampedDepth,
+						treeDepth: depthLabel,
 						responseSizeKB: sizeKB,
 						variablesResolved: data._variableMapSize || 0,
 						note: [
-							`Deep component tree extracted via Plugin API (depth ${clampedDepth}).`,
+							`Deep component tree extracted via Plugin API (depth ${depthLabel}).`,
 							"boundVariables are resolved to token names, collections, and codeSyntax.",
 							"INSTANCE nodes include mainComponent references (key, name, component set).",
 							"Use this data to generate production-quality, token-aware, accessible code.",

--- a/src/core/websocket-connector.ts
+++ b/src/core/websocket-connector.ts
@@ -189,7 +189,9 @@ export class WebSocketConnector implements IFigmaConnector {
   }
 
   async deepGetComponent(nodeId: string, depth?: number): Promise<any> {
-    return this.wsServer.sendCommand('DEEP_GET_COMPONENT', { nodeId, depth: depth || 10 }, 30000);
+    const unlimited = typeof depth === "number" && depth <= 0;
+    const sentDepth = (depth === undefined || depth === null) ? 10 : depth;
+    return this.wsServer.sendCommand('DEEP_GET_COMPONENT', { nodeId, depth: sentDepth }, unlimited ? 120000 : 30000);
   }
 
   async analyzeComponentSet(nodeId: string): Promise<any> {


### PR DESCRIPTION
depth:0 (or any negative value) now traverses the entire subtree with no cap; positive depths are passed through without the previous max-20 clamp.

The unlimited sentinel is threaded through every hop that previously collapsed it via "depth || 10" (which turns 0 into 10): the MCP tool, the websocket connector, and the plugin UI relay.

The deep-extraction timeout is raised to 120s only for unlimited requests; limited requests keep the original 30s.