### PR TITLE
Fix explicit active file drift in multi-file bridge

### DIFF
--- a/src/core/websocket-server.ts
+++ b/src/core/websocket-server.ts
@@ -6,9 +6,12 @@
  * (sent via FILE_INFO on connection). Per-file state (selection, document changes,
  * console logs) is maintained independently.
  *
- * Active file tracking: The "active" file is automatically switched when the user
- * interacts with a file (selection/page changes) or can be set explicitly via
- * setActiveFile(). All backward-compatible getters return data from the active file.
+ * Active file tracking: Until an MCP client explicitly targets a file, the
+ * "active" file follows the latest connected/user-touched file for backward
+ * compatibility. Once setActiveFile() is called (for example via
+ * figma_navigate), the explicit target is sticky: passive peer FILE_INFO,
+ * SELECTION_CHANGE, and PAGE_CHANGE events continue updating per-file state but
+ * no longer silently retarget later tool calls.
  *
  * Data flow: MCP Server ←WebSocket→ ui.html ←postMessage→ code.js ←figma.*→ Figma
  */
@@ -178,6 +181,13 @@ export class FigmaWebSocketServer extends EventEmitter {
   private _pendingClients: Map<WebSocket, ReturnType<typeof setTimeout>> = new Map();
   /** The fileKey of the currently active (targeted) file */
   private _activeFileKey: string | null = null;
+  /**
+   * True after an MCP/client-level action explicitly picked the active file
+   * (setActiveFile(), normally reached through figma_navigate). While true,
+   * background events from other connected files must not silently retarget
+   * subsequent commands.
+   */
+  private _activeFileExplicit = false;
   private pendingRequests: Map<string, PendingRequest> = new Map();
   private requestIdCounter = 0;
   private options: WebSocketServerOptions;
@@ -498,7 +508,14 @@ export class FigmaWebSocketServer extends EventEmitter {
         if (found) {
           found.client.selection = message.data as SelectionInfo;
           found.client.lastActivity = Date.now();
-          this._activeFileKey = found.fileKey;
+          if (!this._activeFileExplicit) {
+            this._activeFileKey = found.fileKey;
+          } else if (this._activeFileKey !== found.fileKey) {
+            logger.debug(
+              { eventFileKey: found.fileKey, activeFileKey: this._activeFileKey },
+              'Ignoring passive selection event from peer file because active file was set explicitly'
+            );
+          }
         }
         this.emit('selectionChange', { fileKey: found?.fileKey ?? null, ...message.data });
       }
@@ -510,7 +527,14 @@ export class FigmaWebSocketServer extends EventEmitter {
           found.client.fileInfo.currentPage = message.data.pageName;
           found.client.fileInfo.currentPageId = message.data.pageId || null;
           found.client.lastActivity = Date.now();
-          this._activeFileKey = found.fileKey;
+          if (!this._activeFileExplicit) {
+            this._activeFileKey = found.fileKey;
+          } else if (this._activeFileKey !== found.fileKey) {
+            logger.debug(
+              { eventFileKey: found.fileKey, activeFileKey: this._activeFileKey },
+              'Ignoring passive page event from peer file because active file was set explicitly'
+            );
+          }
         }
         this.emit('pageChange', { fileKey: found?.fileKey ?? null, ...message.data });
       }
@@ -570,6 +594,7 @@ export class FigmaWebSocketServer extends EventEmitter {
       this.clients.delete(previousEntry.fileKey);
       if (this._activeFileKey === previousEntry.fileKey) {
         this._activeFileKey = null;
+        this._activeFileExplicit = false;
       }
       // In-flight commands to the old file can never receive a response now —
       // reject them immediately instead of leaving them to hang until timeout
@@ -656,10 +681,19 @@ export class FigmaWebSocketServer extends EventEmitter {
       gracePeriodTimer: null,
     });
 
-    // Most recently connected file becomes active (user just opened the plugin there).
-    // On bulk reconnect the order is non-deterministic, but the first user interaction
-    // (SELECTION_CHANGE or PAGE_CHANGE) will correct the active file immediately.
-    this._activeFileKey = fileKey;
+    // Before a client explicitly picks a target, preserve the legacy behavior:
+    // the most recently connected file becomes active and selection/page events
+    // can still auto-switch it. After setActiveFile() pins an explicit target,
+    // FILE_INFO from peer files must not silently steal that target. Same-file
+    // reconnects keep the explicit target intact because fileKey is unchanged.
+    if (!this._activeFileKey || !this._activeFileExplicit || this._activeFileKey === fileKey) {
+      this._activeFileKey = fileKey;
+    } else {
+      logger.debug(
+        { fileKey, activeFileKey: this._activeFileKey },
+        'Ignoring passive FILE_INFO from peer file because active file was set explicitly'
+      );
+    }
 
     logger.info(
       {
@@ -1051,7 +1085,8 @@ export class FigmaWebSocketServer extends EventEmitter {
     const client = this.clients.get(fileKey);
     if (client && client.ws.readyState === WebSocket.OPEN) {
       this._activeFileKey = fileKey;
-      logger.info({ fileKey, fileName: client.fileInfo.fileName }, 'Active file switched');
+      this._activeFileExplicit = true;
+      logger.info({ fileKey, fileName: client.fileInfo.fileName }, 'Active file switched explicitly');
       this.emit('activeFileChanged', { fileKey, fileName: client.fileInfo.fileName });
       return true;
     }
@@ -1137,6 +1172,7 @@ export class FigmaWebSocketServer extends EventEmitter {
     }
     this.clients.clear();
     this._activeFileKey = null;
+    this._activeFileExplicit = false;
 
     // Close WS server first (handles WebSocket connections)
     if (this.wss) {

--- a/src/local.ts
+++ b/src/local.ts
@@ -1008,6 +1008,10 @@ If Design Systems Assistant MCP is not available, install it from: https://githu
 							const isSameFile = !!(requestedFileKey && fileInfo?.fileKey && requestedFileKey === fileInfo.fileKey);
 
 							if (isSameFile) {
+								// Even if the requested file is already active, make the
+								// navigation explicit so passive events from peer files cannot
+								// silently steal subsequent tool calls in multi-file sessions.
+								this.wsServer.setActiveFile(requestedFileKey);
 								return {
 									content: [
 										{

--- a/tests/websocket-bridge.test.ts
+++ b/tests/websocket-bridge.test.ts
@@ -1602,6 +1602,88 @@ describe('Multi-client WebSocket', () => {
 
       expect(server.getActiveFileKey()).toBe('file-a');
     });
+
+    test('explicit setActiveFile is sticky against peer SELECTION_CHANGE', async () => {
+      server = new FigmaWebSocketServer({ port: TEST_PORT });
+      await server.start();
+
+      const c1 = await connectClient(server, TEST_PORT, { fileKey: 'file-a', fileName: 'A' });
+      clients.push(c1);
+      const c2 = await connectClient(server, TEST_PORT, { fileKey: 'file-b', fileName: 'B' });
+      clients.push(c2);
+
+      expect(server.getActiveFileKey()).toBe('file-b');
+      expect(server.setActiveFile('file-a')).toBe(true);
+      expect(server.getActiveFileKey()).toBe('file-a');
+
+      const selPromise = new Promise<void>((resolve) =>
+        server.once('selectionChange', resolve)
+      );
+      c2.send(JSON.stringify({
+        type: 'SELECTION_CHANGE',
+        data: {
+          nodes: [{ id: '2:1', name: 'Peer Frame', type: 'FRAME', width: 100, height: 100 }],
+          count: 1,
+          page: 'Page 1',
+          timestamp: Date.now(),
+        },
+      }));
+      await selPromise;
+
+      expect(server.getActiveFileKey()).toBe('file-a');
+      expect(server.getCurrentSelection()).toBeNull();
+
+      server.setActiveFile('file-b');
+      expect(server.getCurrentSelection()!.nodes[0].name).toBe('Peer Frame');
+    });
+
+    test('explicit setActiveFile is sticky against peer PAGE_CHANGE', async () => {
+      server = new FigmaWebSocketServer({ port: TEST_PORT });
+      await server.start();
+
+      const c1 = await connectClient(server, TEST_PORT, { fileKey: 'file-a', fileName: 'A', currentPage: 'A Page' });
+      clients.push(c1);
+      const c2 = await connectClient(server, TEST_PORT, { fileKey: 'file-b', fileName: 'B', currentPage: 'B Page' });
+      clients.push(c2);
+
+      expect(server.setActiveFile('file-a')).toBe(true);
+
+      const pagePromise = new Promise<void>((resolve) =>
+        server.once('pageChange', resolve)
+      );
+      c2.send(JSON.stringify({
+        type: 'PAGE_CHANGE',
+        data: { pageId: '9:0', pageName: 'Peer Components', timestamp: Date.now() },
+      }));
+      await pagePromise;
+
+      expect(server.getActiveFileKey()).toBe('file-a');
+      expect(server.getConnectedFileInfo()!.currentPage).toBe('A Page');
+
+      server.setActiveFile('file-b');
+      expect(server.getConnectedFileInfo()!.currentPage).toBe('Peer Components');
+    });
+
+    test('explicit setActiveFile is sticky against peer FILE_INFO reconnects', async () => {
+      server = new FigmaWebSocketServer({ port: TEST_PORT });
+      await server.start();
+
+      const c1 = await connectClient(server, TEST_PORT, { fileKey: 'file-a', fileName: 'A' });
+      clients.push(c1);
+      const c2 = await connectClient(server, TEST_PORT, { fileKey: 'file-b', fileName: 'B' });
+      clients.push(c2);
+
+      expect(server.setActiveFile('file-a')).toBe(true);
+      expect(server.getActiveFileKey()).toBe('file-a');
+
+      const c3 = await connectClient(server, TEST_PORT, { fileKey: 'file-c', fileName: 'C' });
+      clients.push(c3);
+
+      expect(server.getActiveFileKey()).toBe('file-a');
+      expect(server.getConnectedFiles().map(f => f.fileKey)).toEqual(
+        expect.arrayContaining(['file-a', 'file-b', 'file-c'])
+      );
+    });
   });
 
   describe('per-file state isolation', () => {


### PR DESCRIPTION
## Summary

Fixes #72.

This makes explicit multi-file targeting sticky in the local WebSocket Desktop Bridge. Before an MCP client explicitly targets a file, the legacy behavior is preserved: the active file follows the latest connected/user-touched file. After `setActiveFile()` is called (normally through `figma_navigate`), passive peer `FILE_INFO`, `SELECTION_CHANGE`, and `PAGE_CHANGE` events continue updating per-file state, but no longer silently retarget subsequent tool calls.

## Why

In multi-file sessions, background events from another Figma file can currently override an explicit `figma_navigate()` target. That makes long-running agent workflows unsafe: an operation can begin in file A and silently continue in file B after a tab focus, selection event, page event, or plugin reconnect.

## Changes

- Add an explicit active-file mode to `FigmaWebSocketServer`.
- Preserve implicit auto-switching until a caller explicitly chooses a target.
- Prevent peer selection/page events from stealing an explicit active target.
- Prevent peer `FILE_INFO` reconnects/new file connections from stealing an explicit active target.
- Keep same-file reconnects working without clearing the explicit target.
- Reset explicit mode only when the active file is removed/disconnected and the server falls back to another connected file.
- Make the `figma_navigate` already-connected path call `setActiveFile()` so it pins the target explicitly even when the requested file is already active.
- Add regression coverage for peer `SELECTION_CHANGE`, `PAGE_CHANGE`, and `FILE_INFO` reconnect/new-file drift.

## Validation

Run on OVH using the upstream repo checkout on branch `fix-explicit-active-file-lock`.

- `npm ci --include=dev` ✅
- `npx -y node@22 node_modules/jest/bin/jest.js tests/websocket-bridge.test.ts --runInBand` ✅
- `npx -y node@22 node_modules/typescript/bin/tsc -p tsconfig.local.json --noEmit` ✅
- `npx -y node@22 node_modules/typescript/bin/tsc --project tsconfig.local.json` ✅
- `npx -y node@22 node_modules/jest/bin/jest.js --runInBand` ✅ — 45 suites / 1339 tests passed
- `git diff --check` ✅

Note: full `tsc --noEmit` still reports existing app UI type errors in `src/apps/*/ui/mcp-app.ts` unrelated to this change. The touched local-server path passes `tsconfig.local.json` type-check and build, and the full Jest suite passes under Node 22.
