### PR TITLE
docs: add designer-oriented setup tutorial to Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,6 +891,7 @@ MIT - See [LICENSE](LICENSE) file for details.
 ## 🔗 Links
 
 - 📚 **[Documentation Site](https://docs.figma-console-mcp.southleft.com)** — Complete guides, tutorials, and API reference
+- ✍️ [Designer setup walkthrough](https://amplifai.design/setup-guide) — community tutorial: full beginner setup for designers (Claude Code + official Figma MCP + Figma Console MCP + Desktop Bridge), ending with a first design-to-code build
 - 📖 [Local Docs](docs/) — Documentation source files
 - 🐛 [Report Issues](https://github.com/southleft/figma-console-mcp/issues)
 - 💬 [Discussions](https://github.com/southleft/figma-console-mcp/discussions)


### PR DESCRIPTION
Hi! We wrote a beginner-friendly, step-by-step setup walkthrough for **designers** (no engineering background) that uses figma-console-mcp alongside the official Figma MCP server — covering install, token setup, the Desktop Bridge plugin, and a first design-to-code build on localhost.

Adding it to the Links section in case it helps your non-engineer users get started: https://amplifai.design/setup-guide

Disclosure: we authored the guide (it's a free resource, the written version of a course module). Happy to move it to a different section or adjust the wording — or close if external tutorials aren't wanted here. Thanks for the great tool!