### PR TITLE
feat: per-file targeting and concurrent cross-file execution (figma_execute_across_files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Figma Console MCP connects AI assistants (like Claude) to Figma, enabling:
 | Real-time monitoring (console, selection) | ✅ | ❌ | ❌ |
 | Desktop Bridge plugin | ✅ | ✅ | ❌ |
 | Requires Node.js | Yes | **No** | No |
-| **Total tools available** | **113** | **101** | **9** |
+| **Total tools available** | **114** | **101** | **9** |
 
-> **Bottom line:** Remote SSE is **read-only** with 9 tools. **Cloud Mode** unlocks write access (101 tools) from web AI clients without Node.js. NPX/Local Git gives the full 113 tools with real-time monitoring.
+> **Bottom line:** Remote SSE is **read-only** with 9 tools. **Cloud Mode** unlocks write access (101 tools) from web AI clients without Node.js. NPX/Local Git gives the full 114 tools with real-time monitoring.
 
 ---
 
@@ -66,7 +66,7 @@ Figma Console MCP connects AI assistants (like Claude) to Figma, enabling:
 
 **Best for:** Designers who want full AI-assisted design capabilities.
 
-**What you get:** All 113 tools including design creation, variable management, and component instantiation.
+**What you get:** All 114 tools including design creation, variable management, and component instantiation.
 
 #### Prerequisites
 
@@ -163,7 +163,7 @@ Create a simple frame with a blue background
 
 **Best for:** Developers who want to modify source code or contribute to the project.
 
-**What you get:** Same 113 tools as NPX, plus full source code access.
+**What you get:** Same 114 tools as NPX, plus full source code access.
 
 #### Quick Setup
 
@@ -309,7 +309,7 @@ AI Client → Cloud MCP Server → Durable Object Relay → Desktop Bridge Plugi
 | Feature | NPX (Recommended) | Cloud Mode | Local Git | Remote SSE |
 |---------|-------------------|------------|-----------|------------|
 | **Setup time** | ~10 minutes | ~5 minutes | ~15 minutes | ~2 minutes |
-| **Total tools** | **113** | **101** | **113** | **9** (read-only) |
+| **Total tools** | **114** | **101** | **114** | **9** (read-only) |
 | **Design creation** | ✅ | ✅ | ✅ | ❌ |
 | **Variable management** | ✅ | ✅ | ✅ | ❌ |
 | **Component instantiation** | ✅ | ✅ | ✅ | ❌ |
@@ -324,7 +324,7 @@ AI Client → Cloud MCP Server → Durable Object Relay → Desktop Bridge Plugi
 | **Automatic updates** | ✅ (`@latest`) | ✅ | Manual (`git pull`) | ✅ |
 | **Source code access** | ❌ | ❌ | ✅ | ❌ |
 
-> **Key insight:** Remote SSE is read-only. Cloud Mode adds write access for web AI clients without Node.js. NPX/Local Git give the full 113 tools.
+> **Key insight:** Remote SSE is read-only. Cloud Mode adds write access for web AI clients without Node.js. NPX/Local Git give the full 114 tools.
 
 **📖 [Complete Feature Comparison](docs/mode-comparison.md)**
 
@@ -417,6 +417,8 @@ When you first use design system tools:
   - Create frames, shapes, text, components
   - Apply auto-layout, styles, effects
   - Build complete UI mockups programmatically
+  - Optional `fileKey` targets one specific connected file directly (Local Mode), without touching the active file or target lock
+- `figma_execute_across_files` - **Local Mode only.** Fan the same script out to every (or a chosen subset of) Desktop Bridge-connected files concurrently, returning a per-file result map — for cross-file consistency checks/fixes across a multi-file design system, replacing "open file, run plugin, repeat per file"
 - `figma_create_component_set` - **Create a component set with variants in one declarative call**
   - Generate every variant combination from an axes matrix (e.g. `{ State: ["default", "hover", "disabled"], Size: ["sm", "lg"] }` → 6 variants) off a base component, or combine existing components
   - `Prop=Value` variant naming, `combineAsVariants` under the hood, optional auto-arranged labeled grid
@@ -682,7 +684,7 @@ The **Figma Desktop Bridge** plugin is the recommended way to connect Figma to t
 - The MCP server communicates via **WebSocket** through the Desktop Bridge plugin
 - The server tries port 9223 first, then automatically falls back through ports 9224–9232 if needed
 - The plugin scans all ports in the range and connects to every active server it finds
-- All 113 tools work through the WebSocket transport
+- All 114 tools work through the WebSocket transport
 
 **Multiple files:** The WebSocket server supports multiple simultaneous plugin connections — one per open Figma file. Each connection is tracked by file key with independent state (selection, document changes, console logs).
 

--- a/src/core/cloud-websocket-connector.ts
+++ b/src/core/cloud-websocket-connector.ts
@@ -74,7 +74,10 @@ export class CloudWebSocketConnector implements IFigmaConnector {
 		return this.sendCommand('EXECUTE_CODE', { code, timeout: 30000 }, 32000);
 	}
 
-	async executeCodeViaUI(code: string, timeoutMs = 5000): Promise<any> {
+	async executeCodeViaUI(code: string, timeoutMs = 5000, fileKey?: string): Promise<any> {
+		// fileKey is accepted for IFigmaConnector parity but unused here — the
+		// cloud relay pairs with exactly one plugin instance, so there is no
+		// multi-file target to route between (matches getVariables* above).
 		return this.sendCommand('EXECUTE_CODE', { code, timeout: timeoutMs }, timeoutMs + 2000);
 	}
 

--- a/src/core/figma-connector.ts
+++ b/src/core/figma-connector.ts
@@ -14,7 +14,7 @@ export interface IFigmaConnector {
   executeInPluginContext<T = any>(code: string): Promise<T>;
   getVariablesFromPluginUI(fileKey?: string): Promise<any>;
   getVariables(fileKey?: string): Promise<any>;
-  executeCodeViaUI(code: string, timeoutMs?: number): Promise<any>;
+  executeCodeViaUI(code: string, timeoutMs?: number, fileKey?: string): Promise<any>;
 
   // Variable operations
   updateVariable(variableId: string, modeId: string, value: any): Promise<any>;

--- a/src/core/multi-file-tools.ts
+++ b/src/core/multi-file-tools.ts
@@ -1,0 +1,151 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { FigmaWebSocketServer } from "./websocket-server.js";
+
+/**
+ * Register tools that operate across every Figma file connected via the
+ * Desktop Bridge plugin at once, rather than only the single active file.
+ * Local mode only — cloud/relay mode pairs with exactly one plugin instance.
+ */
+export function registerMultiFileTools(
+	server: McpServer,
+	getWsServer: () => FigmaWebSocketServer | null,
+	getDesktopConnector: () => Promise<any>,
+) {
+	server.tool(
+		"figma_execute_across_files",
+		"Run the same JavaScript against multiple Figma files connected via the Desktop Bridge plugin, IN PARALLEL, without touching the active file or target lock. Built for cross-file consistency work — e.g. running the same structural check or fix against every file in a multi-file design system and diffing the results — instead of switching the active file and running figma_execute once per file in sequence. Each file's code runs in that file's own plugin context (same 'figma' global as figma_execute); a fix targeting only some files should read figma_list_open_files first, then pass just those fileKeys. Requires Desktop Bridge plugin open in each target file.",
+		{
+			code: z
+				.string()
+				.describe(
+					"JavaScript code to execute in each targeted file. Has access to the 'figma' global object, same as figma_execute. Example: 'return { pageCount: figma.root.children.length };'",
+				),
+			fileKeys: z
+				.array(z.string())
+				.optional()
+				.describe(
+					"Which connected files to target, by fileKey. Omit (or pass an empty array) to run against every currently connected file. Get fileKeys from figma_list_open_files.",
+				),
+			timeout: z
+				.number()
+				.optional()
+				.default(10000)
+				.describe(
+					"Per-file execution timeout in milliseconds (default: 10000, max: 30000). Applies independently to each file — one slow/unresponsive file does not delay the others.",
+				),
+		},
+		async ({ code, fileKeys, timeout }: { code: string; fileKeys?: string[]; timeout: number }) => {
+			try {
+				const wsServer = getWsServer();
+				if (!wsServer?.isClientConnected()) {
+					return {
+						content: [{
+							type: "text" as const,
+							text: JSON.stringify({
+								error: "No files connected. Open the Desktop Bridge plugin in Figma to connect files.",
+								results: {},
+							}),
+						}],
+						isError: true,
+					};
+				}
+
+				const connectedFiles = wsServer.getConnectedFiles();
+				const cappedTimeout = Math.min(timeout, 30000);
+
+				let targets = connectedFiles;
+				let missingFileKeys: string[] = [];
+				if (fileKeys && fileKeys.length > 0) {
+					const connectedKeySet = new Set(connectedFiles.map((f) => f.fileKey));
+					missingFileKeys = fileKeys.filter((k) => !connectedKeySet.has(k));
+					targets = connectedFiles.filter(
+						(f) => f.fileKey && fileKeys.includes(f.fileKey),
+					);
+				}
+
+				if (targets.length === 0) {
+					return {
+						content: [{
+							type: "text" as const,
+							text: JSON.stringify({
+								error: "No matching connected files to target.",
+								requestedFileKeys: fileKeys,
+								connectedFileKeys: connectedFiles.map((f) => f.fileKey),
+							}),
+						}],
+						isError: true,
+					};
+				}
+
+				const connector = await getDesktopConnector();
+				const outcomes = await Promise.allSettled(
+					targets.map((file) =>
+						connector.executeCodeViaUI(
+							code,
+							cappedTimeout,
+							file.fileKey ?? undefined,
+						),
+					),
+				);
+
+				const results: Record<string, unknown> = {};
+				let succeeded = 0;
+				let failed = 0;
+				outcomes.forEach((outcome, i) => {
+					const file = targets[i];
+					const key = file.fileKey || `unknown-${i}`;
+					if (outcome.status === "fulfilled") {
+						const result = outcome.value;
+						const ok = result?.success !== false;
+						if (ok) succeeded++;
+						else failed++;
+						results[key] = {
+							fileName: file.fileName,
+							success: result?.success,
+							result: result?.result,
+							error: result?.error,
+						};
+					} else {
+						failed++;
+						results[key] = {
+							fileName: file.fileName,
+							success: false,
+							error:
+								outcome.reason instanceof Error
+									? outcome.reason.message
+									: String(outcome.reason),
+						};
+					}
+				});
+
+				return {
+					content: [{
+						type: "text" as const,
+						text: JSON.stringify({
+							results,
+							totalTargeted: targets.length,
+							totalSucceeded: succeeded,
+							totalFailed: failed,
+							missingFileKeys:
+								missingFileKeys.length > 0 ? missingFileKeys : undefined,
+							timestamp: Date.now(),
+						}),
+					}],
+					isError: failed > 0 && succeeded === 0,
+				};
+			} catch (error) {
+				return {
+					content: [{
+						type: "text" as const,
+						text: JSON.stringify({
+							error: error instanceof Error ? error.message : String(error),
+							message: "Failed to execute across files",
+						}),
+					}],
+					isError: true,
+				};
+			}
+		},
+	);
+}

--- a/src/core/websocket-connector.ts
+++ b/src/core/websocket-connector.ts
@@ -119,8 +119,11 @@ export class WebSocketConnector implements IFigmaConnector {
     return this.wsServer.sendCommand('EXECUTE_CODE', { code, timeout: 30000 }, 32000, fileKey);
   }
 
-  async executeCodeViaUI(code: string, timeoutMs = 5000): Promise<any> {
-    return this.wsServer.sendCommand('EXECUTE_CODE', { code, timeout: timeoutMs }, timeoutMs + 2000);
+  async executeCodeViaUI(code: string, timeoutMs = 5000, fileKey?: string): Promise<any> {
+    // fileKey is optional — when passed, routes to that specific connected
+    // client instead of the active file (see sendCommand's targetFileKey),
+    // so code can run against a non-active file without switching to it.
+    return this.wsServer.sendCommand('EXECUTE_CODE', { code, timeout: timeoutMs }, timeoutMs + 2000, fileKey);
   }
 
   // ============================================================================

--- a/src/core/write-tools.ts
+++ b/src/core/write-tools.ts
@@ -34,7 +34,9 @@ When creating: place inside a named Section, positioned BELOW or AWAY from exist
 After creating: screenshot to verify clean placement and no overlaps.
 On failure/retry: DELETE any partial artifacts (empty frames, orphaned layers, blank pages) before retrying. Use node.remove() to clean up.
 Pages: NEVER create a new page if one with that name already exists — use the existing one. If you created a blank page during a failed attempt, delete it.
-Layers: If your code creates helper frames, placeholder nodes, or intermediate layers that aren't part of the final result, remove them.`,
+Layers: If your code creates helper frames, placeholder nodes, or intermediate layers that aren't part of the final result, remove them.
+
+**MULTI-FILE:** Pass fileKey to run this in a specific connected file without switching the active file/target lock (see figma_list_open_files). To run the same code across every connected file at once, use figma_execute_across_files instead.`,
 		{
 			code: z
 				.string()
@@ -49,13 +51,20 @@ Layers: If your code creates helper frames, placeholder nodes, or intermediate l
 				.describe(
 					"Execution timeout in milliseconds (default: 5000, max: 30000)",
 				),
+			fileKey: z
+				.string()
+				.optional()
+				.describe(
+					"Run against this specific connected file instead of the active file. Does not change the active file or target lock. Get connected fileKeys from figma_list_open_files.",
+				),
 		},
-		async ({ code, timeout }) => {
+		async ({ code, timeout, fileKey }) => {
 			try {
 				const connector = await getDesktopConnector();
 				const result = await connector.executeCodeViaUI(
 					code,
 					Math.min(timeout, 30000),
+					fileKey,
 				);
 
 				return {

--- a/src/local.ts
+++ b/src/local.ts
@@ -40,6 +40,7 @@ import { registerLibraryTools, registerLibraryVariableTools } from "./core/libra
 import { registerAccessibilityTools } from "./core/accessibility-tools.js";
 import { registerDiagnoseTool } from "./core/diagnose-tool.js";
 import { registerWriteTools } from "./core/write-tools.js";
+import { registerMultiFileTools } from "./core/multi-file-tools.js";
 import { registerTokensTools } from "./core/tokens-tools.js";
 import { wrapServerForIdentity } from "./core/identity.js";
 import { PACKAGE_ROOT } from "./core/resolve-package-root.js";
@@ -3059,6 +3060,16 @@ Without libraryFileKey/libraryFileUrl, searches the currently open file (local c
 		// design-token setup, accessibility audits, etc.). Sourced from src/core/write-tools.ts
 		// so local mode and cloud mode share the same 30 implementations — no risk of drift.
 		registerWriteTools(this.server, () => this.getDesktopConnector());
+
+		// Register cross-file tools (figma_execute_across_files) — run the same
+		// code against every (or a chosen subset of) currently connected files
+		// concurrently. Local mode only, needs direct wsServer access for
+		// getConnectedFiles(), so it isn't part of the connector abstraction.
+		registerMultiFileTools(
+			this.server,
+			() => this.wsServer,
+			() => this.getDesktopConnector(),
+		);
 
 		// Register token sync tools — figma_export_tokens and figma_import_tokens.
 		// Replace Style Dictionary and Tokens Studio's export pipeline for the

--- a/tests/multi-file-tools.test.ts
+++ b/tests/multi-file-tools.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Multi-File Tools Tests
+ *
+ * Unit tests for registerMultiFileTools() — figma_execute_across_files fans
+ * a single script out to every (or a chosen subset of) connected Desktop
+ * Bridge files concurrently, without touching the active file/target lock.
+ */
+
+import { registerMultiFileTools } from "../src/core/multi-file-tools";
+
+// ============================================================================
+// Mock infrastructure
+// ============================================================================
+
+interface RegisteredTool {
+	name: string;
+	description: string;
+	schema: any;
+	handler: (args: any) => Promise<any>;
+}
+
+function createMockServer() {
+	const tools: Record<string, RegisteredTool> = {};
+	return {
+		tool: jest.fn(
+			(name: string, description: string, schema: any, handler: any) => {
+				tools[name] = { name, description, schema, handler };
+			},
+		),
+		_tools: tools,
+		_getTool(name: string): RegisteredTool {
+			return tools[name];
+		},
+	};
+}
+
+function connectedFile(fileKey: string, fileName: string, isActive = false) {
+	return { fileKey, fileName, currentPage: "Page 1", connectedAt: Date.now(), isActive };
+}
+
+function createMockWsServer(files: ReturnType<typeof connectedFile>[]) {
+	return {
+		isClientConnected: jest.fn().mockReturnValue(files.length > 0),
+		getConnectedFiles: jest.fn().mockReturnValue(files),
+	};
+}
+
+function parseResult(result: any): any {
+	return JSON.parse(result.content[0].text);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Multi-File Tools", () => {
+	let server: ReturnType<typeof createMockServer>;
+
+	beforeEach(() => {
+		server = createMockServer();
+	});
+
+	it("registers exactly 1 tool", () => {
+		const wsServer = createMockWsServer([]);
+		registerMultiFileTools(server as any, () => wsServer as any, async () => ({}));
+		expect(server.tool).toHaveBeenCalledTimes(1);
+		expect(server._getTool("figma_execute_across_files")).toBeDefined();
+	});
+
+	describe("figma_execute_across_files", () => {
+		it("errors when no files are connected", async () => {
+			const wsServer = createMockWsServer([]);
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({}));
+			const tool = server._getTool("figma_execute_across_files");
+
+			const result = await tool.handler({ code: "return 1", timeout: 5000 });
+
+			expect(result.isError).toBe(true);
+			expect(parseResult(result).error).toContain("No files connected");
+		});
+
+		it("runs code against every connected file when fileKeys is omitted", async () => {
+			const files = [
+				connectedFile("file-a", "Nova", true),
+				connectedFile("file-b", "Vega"),
+				connectedFile("file-c", "Luma"),
+			];
+			const wsServer = createMockWsServer(files);
+			const executeCodeViaUI = jest.fn().mockResolvedValue({ success: true, result: { pages: 5 } });
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({ executeCodeViaUI }));
+			const tool = server._getTool("figma_execute_across_files");
+
+			const result = await tool.handler({ code: "return { pages: 5 };", timeout: 5000 });
+			const parsed = parseResult(result);
+
+			expect(executeCodeViaUI).toHaveBeenCalledTimes(3);
+			expect(executeCodeViaUI).toHaveBeenCalledWith("return { pages: 5 };", 5000, "file-a");
+			expect(executeCodeViaUI).toHaveBeenCalledWith("return { pages: 5 };", 5000, "file-b");
+			expect(executeCodeViaUI).toHaveBeenCalledWith("return { pages: 5 };", 5000, "file-c");
+			expect(parsed.totalTargeted).toBe(3);
+			expect(parsed.totalSucceeded).toBe(3);
+			expect(parsed.totalFailed).toBe(0);
+			expect(parsed.results["file-a"]).toEqual({
+				fileName: "Nova",
+				success: true,
+				result: { pages: 5 },
+				error: undefined,
+			});
+		});
+
+		it("dispatches concurrently, not sequentially", async () => {
+			const files = [connectedFile("file-a", "Nova"), connectedFile("file-b", "Vega")];
+			const wsServer = createMockWsServer(files);
+			const order: string[] = [];
+			const executeCodeViaUI = jest.fn((code: string, timeout: number, fileKey?: string) => {
+				order.push(`start:${fileKey}`);
+				const delay = fileKey === "file-a" ? 20 : 5;
+				return new Promise((resolve) =>
+					setTimeout(() => {
+						order.push(`end:${fileKey}`);
+						resolve({ success: true, result: null });
+					}, delay),
+				);
+			});
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({ executeCodeViaUI }));
+			const tool = server._getTool("figma_execute_across_files");
+
+			await tool.handler({ code: "return 1;", timeout: 5000 });
+
+			// Both dispatches fire before either resolves — file-b (shorter
+			// delay) finishes before file-a, which is impossible if the calls
+			// were serialized file-a-then-file-b.
+			expect(order).toEqual(["start:file-a", "start:file-b", "end:file-b", "end:file-a"]);
+		});
+
+		it("only targets the requested fileKeys when provided", async () => {
+			const files = [
+				connectedFile("file-a", "Nova"),
+				connectedFile("file-b", "Vega"),
+				connectedFile("file-c", "Luma"),
+			];
+			const wsServer = createMockWsServer(files);
+			const executeCodeViaUI = jest.fn().mockResolvedValue({ success: true, result: null });
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({ executeCodeViaUI }));
+			const tool = server._getTool("figma_execute_across_files");
+
+			const result = await tool.handler({
+				code: "return 1;",
+				fileKeys: ["file-a", "file-c"],
+				timeout: 5000,
+			});
+			const parsed = parseResult(result);
+
+			expect(executeCodeViaUI).toHaveBeenCalledTimes(2);
+			expect(executeCodeViaUI).toHaveBeenCalledWith("return 1;", 5000, "file-a");
+			expect(executeCodeViaUI).toHaveBeenCalledWith("return 1;", 5000, "file-c");
+			expect(parsed.totalTargeted).toBe(2);
+			expect(Object.keys(parsed.results).sort()).toEqual(["file-a", "file-c"]);
+		});
+
+		it("reports requested fileKeys that aren't connected without dropping valid ones", async () => {
+			const files = [connectedFile("file-a", "Nova")];
+			const wsServer = createMockWsServer(files);
+			const executeCodeViaUI = jest.fn().mockResolvedValue({ success: true, result: null });
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({ executeCodeViaUI }));
+			const tool = server._getTool("figma_execute_across_files");
+
+			const result = await tool.handler({
+				code: "return 1;",
+				fileKeys: ["file-a", "file-nonexistent"],
+				timeout: 5000,
+			});
+			const parsed = parseResult(result);
+
+			expect(parsed.totalTargeted).toBe(1);
+			expect(parsed.missingFileKeys).toEqual(["file-nonexistent"]);
+			expect(Object.keys(parsed.results)).toEqual(["file-a"]);
+		});
+
+		it("errors when none of the requested fileKeys are connected", async () => {
+			const files = [connectedFile("file-a", "Nova")];
+			const wsServer = createMockWsServer(files);
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({}));
+			const tool = server._getTool("figma_execute_across_files");
+
+			const result = await tool.handler({
+				code: "return 1;",
+				fileKeys: ["file-nonexistent"],
+				timeout: 5000,
+			});
+
+			expect(result.isError).toBe(true);
+			expect(parseResult(result).error).toContain("No matching connected files");
+		});
+
+		it("keeps per-file results independent when one file's script throws and another succeeds", async () => {
+			const files = [connectedFile("file-a", "Nova"), connectedFile("file-b", "Vega")];
+			const wsServer = createMockWsServer(files);
+			const executeCodeViaUI = jest.fn((_code: string, _timeout: number, fileKey?: string) => {
+				if (fileKey === "file-a") return Promise.reject(new Error("Timeout"));
+				return Promise.resolve({ success: true, result: { ok: true } });
+			});
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({ executeCodeViaUI }));
+			const tool = server._getTool("figma_execute_across_files");
+
+			const result = await tool.handler({ code: "return 1;", timeout: 5000 });
+			const parsed = parseResult(result);
+
+			expect(result.isError).toBe(false);
+			expect(parsed.totalSucceeded).toBe(1);
+			expect(parsed.totalFailed).toBe(1);
+			expect(parsed.results["file-a"]).toEqual({
+				fileName: "Nova",
+				success: false,
+				error: "Timeout",
+			});
+			expect(parsed.results["file-b"].success).toBe(true);
+		});
+
+		it("marks the response isError when every targeted file fails", async () => {
+			const files = [connectedFile("file-a", "Nova"), connectedFile("file-b", "Vega")];
+			const wsServer = createMockWsServer(files);
+			const executeCodeViaUI = jest.fn().mockRejectedValue(new Error("boom"));
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({ executeCodeViaUI }));
+			const tool = server._getTool("figma_execute_across_files");
+
+			const result = await tool.handler({ code: "return 1;", timeout: 5000 });
+			const parsed = parseResult(result);
+
+			expect(result.isError).toBe(true);
+			expect(parsed.totalSucceeded).toBe(0);
+			expect(parsed.totalFailed).toBe(2);
+		});
+
+		it("treats a script-level success:false as a per-file failure without throwing", async () => {
+			const files = [connectedFile("file-a", "Nova")];
+			const wsServer = createMockWsServer(files);
+			const executeCodeViaUI = jest
+				.fn()
+				.mockResolvedValue({ success: false, error: "ReferenceError: x is not defined" });
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({ executeCodeViaUI }));
+			const tool = server._getTool("figma_execute_across_files");
+
+			const result = await tool.handler({ code: "return x;", timeout: 5000 });
+			const parsed = parseResult(result);
+
+			expect(parsed.totalFailed).toBe(1);
+			expect(parsed.results["file-a"].error).toBe("ReferenceError: x is not defined");
+		});
+
+		it("caps timeout at 30000ms even when a higher value is requested", async () => {
+			const files = [connectedFile("file-a", "Nova")];
+			const wsServer = createMockWsServer(files);
+			const executeCodeViaUI = jest.fn().mockResolvedValue({ success: true, result: null });
+			registerMultiFileTools(server as any, () => wsServer as any, async () => ({ executeCodeViaUI }));
+			const tool = server._getTool("figma_execute_across_files");
+
+			await tool.handler({ code: "return 1;", timeout: 999999 });
+
+			expect(executeCodeViaUI).toHaveBeenCalledWith("return 1;", 30000, "file-a");
+		});
+	});
+});

--- a/tests/write-tools.test.ts
+++ b/tests/write-tools.test.ts
@@ -129,14 +129,21 @@ describe("Write Tools", () => {
 			const tool = server._getTool("figma_execute");
 			await tool.handler({ code: "return 1", timeout: 99999 });
 
-			expect(mockConnector.executeCodeViaUI).toHaveBeenCalledWith("return 1", 30000);
+			expect(mockConnector.executeCodeViaUI).toHaveBeenCalledWith("return 1", 30000, undefined);
 		});
 
 		it("passes through smaller timeouts unchanged", async () => {
 			const tool = server._getTool("figma_execute");
 			await tool.handler({ code: "return 1", timeout: 3000 });
 
-			expect(mockConnector.executeCodeViaUI).toHaveBeenCalledWith("return 1", 3000);
+			expect(mockConnector.executeCodeViaUI).toHaveBeenCalledWith("return 1", 3000, undefined);
+		});
+
+		it("passes fileKey through to target a specific connected file", async () => {
+			const tool = server._getTool("figma_execute");
+			await tool.handler({ code: "return 1", timeout: 3000, fileKey: "file-b" });
+
+			expect(mockConnector.executeCodeViaUI).toHaveBeenCalledWith("return 1", 3000, "file-b");
 		});
 
 		it("returns resultAnalysis and fileContext in response", async () => {


### PR DESCRIPTION
Hi TJ, yesterday I had the need to control multiple files at once with Figma Console MCP. Namely, 9 files.

I had Claude investigate a logic around better concurrency, and I believe it did make a meaningful change to the codebase that might benefit other users.

*(Everything below this line was written by Claude based on the actual diff — flagging that up front.)*

## Problem
Driving many simultaneous Desktop Bridge connections (e.g. 9 files open at once) feels serialized, even though nothing in the transport actually is: `sendCommand` already supports addressing a specific connected client via `targetFileKey`, and `pendingRequests` is keyed by request id rather than a single in-flight flag. The actual gap was that no tool threaded a `fileKey` down to it, and target lock only ever pins one global target.

## Changes
- `figma_execute` gains an optional `fileKey` param, threaded through `executeCodeViaUI` to `sendCommand`'s existing `targetFileKey` argument, so code can run against a specific connected file without touching the active file or target lock.
- New `figma_execute_across_files` tool (`src/core/multi-file-tools.ts`) fans the same script out to every (or a chosen subset of) connected files via `Promise.allSettled` and returns a per-file result map — built for cross-file consistency checks/fixes across a multi-file design system, replacing "open file, run plugin, repeat per file."
- README tool list + tool-count tables updated (113 → 114, Local Mode only — Cloud Mode is unaffected since the relay pairs with exactly one plugin instance).

Transport, target lock, and port-discovery are unchanged — this is additive at the tool/connector layer only.

## Testing
- New test suite (`tests/multi-file-tools.test.ts`) covers: no-connections error, fan-out to all connected files, targeting a subset by `fileKey`, missing-fileKey reporting, per-file failure isolation (one file throwing doesn't affect others), timeout capping, and — the key claim — a test asserting genuinely concurrent (not serialized) dispatch via completion order across two files with different artificial delays.
- `write-tools.test.ts` extended to cover the new `fileKey` passthrough on `figma_execute`.
- Full suite passes: 51 suites / 1434 tests. `tsc -p tsconfig.local.json` clean.

No breaking changes — `fileKey` is optional everywhere and existing calls are byte-identical.
