### PR TITLE
feat: add fileKey targeting to the Figma Slots tool family

### DIFF
--- a/src/core/cloud-websocket-connector.ts
+++ b/src/core/cloud-websocket-connector.ts
@@ -267,11 +267,29 @@ export class CloudWebSocketConnector implements IFigmaConnector {
 	// Slot operations
 	// ============================================================================
 
-	async createSlot(nodeId: string, options?: { name?: string; width?: number; height?: number; layoutMode?: string }): Promise<any> {
+	private rejectFileKey(fileKey?: string): void {
+		// fileKey exists on these methods for IFigmaConnector parity but cannot be
+		// honored here — the cloud relay pairs with exactly one plugin instance,
+		// so there is no multi-file target to route between (matches
+		// executeCodeViaUI above). Reject rather than silently running against
+		// the paired file: a caller that asked for file B and got a successful
+		// write to file A has no way to tell from the response that it was misrouted.
+		if (fileKey) {
+			throw new Error(
+				'Per-file targeting (fileKey) is Local Mode only. Cloud Mode pairs with a single ' +
+				'plugin instance, so there is no second file to route to. Omit fileKey to run ' +
+				'against the paired file, or use Local Mode (NPX/Git) for multi-file work.'
+			);
+		}
+	}
+
+	async createSlot(nodeId: string, options?: { name?: string; width?: number; height?: number; layoutMode?: string }, fileKey?: string): Promise<any> {
+		this.rejectFileKey(fileKey);
 		return this.sendCommand('CREATE_SLOT', { nodeId, ...options });
 	}
 
-	async getSlots(nodeId: string): Promise<any> {
+	async getSlots(nodeId: string, fileKey?: string): Promise<any> {
+		this.rejectFileKey(fileKey);
 		return this.sendCommand('GET_SLOTS', { nodeId });
 	}
 
@@ -284,11 +302,13 @@ export class CloudWebSocketConnector implements IFigmaConnector {
 		properties?: Record<string, string | number>;
 		clone?: boolean;
 		clearExisting?: boolean;
-	}): Promise<any> {
+	}, fileKey?: string): Promise<any> {
+		this.rejectFileKey(fileKey);
 		return this.sendCommand('APPEND_TO_SLOT', params);
 	}
 
-	async resetSlot(params: { slotId?: string; instanceId?: string; slotName?: string }): Promise<any> {
+	async resetSlot(params: { slotId?: string; instanceId?: string; slotName?: string }, fileKey?: string): Promise<any> {
+		this.rejectFileKey(fileKey);
 		return this.sendCommand('RESET_SLOT', params);
 	}
 

--- a/src/core/figma-connector.ts
+++ b/src/core/figma-connector.ts
@@ -56,8 +56,8 @@ export interface IFigmaConnector {
   }): Promise<any>;
 
   // Slot operations (Figma Slots open beta)
-  createSlot(nodeId: string, options?: { name?: string; width?: number; height?: number; layoutMode?: string }): Promise<any>;
-  getSlots(nodeId: string): Promise<any>;
+  createSlot(nodeId: string, options?: { name?: string; width?: number; height?: number; layoutMode?: string }, fileKey?: string): Promise<any>;
+  getSlots(nodeId: string, fileKey?: string): Promise<any>;
   appendToSlot(params: {
     slotId?: string;
     instanceId?: string;
@@ -67,8 +67,8 @@ export interface IFigmaConnector {
     properties?: Record<string, string | number>;
     clone?: boolean;
     clearExisting?: boolean;
-  }): Promise<any>;
-  resetSlot(params: { slotId?: string; instanceId?: string; slotName?: string }): Promise<any>;
+  }, fileKey?: string): Promise<any>;
+  resetSlot(params: { slotId?: string; instanceId?: string; slotName?: string }, fileKey?: string): Promise<any>;
 
   // Node manipulation
   resizeNode(nodeId: string, width: number, height: number, withConstraints?: boolean): Promise<any>;

--- a/src/core/slot-tools.ts
+++ b/src/core/slot-tools.ts
@@ -21,6 +21,16 @@ const preferredValueSchema = z.object({
 	key: z.string().describe("Component or component set key"),
 });
 
+const fileKeySchema = z
+	.string()
+	.optional()
+	.describe(
+		"Local Mode only. Run against this specific connected file instead of the active file. Does not change the active file or target lock. Get connected fileKeys from figma_list_open_files. Rejected in Cloud Mode, which pairs with a single plugin instance.",
+	);
+
+const FILE_KEY_DOC =
+	"\n\n**MULTI-FILE (Local Mode only):** Pass fileKey to run this against a specific connected file without switching the active file/target lock (see figma_list_open_files). Does not change the active file or target lock. Cloud Mode pairs with a single plugin instance and rejects fileKey.";
+
 /**
  * Register MCP tools for Figma Slots (open beta).
  * Requires Desktop Bridge and a Figma Desktop version with SlotNode API support.
@@ -31,7 +41,7 @@ export function registerSlotTools(
 ): void {
 	server.tool(
 		"figma_create_slot",
-		`Create a SlotNode inside a component using createSlot(). Automatically creates a linked SLOT component property named after the slot (renaming the slot renames the property). Slots are freeform drop zones for instance content — more flexible than INSTANCE_SWAP. Works on standalone COMPONENTs and variant COMPONENTs inside a COMPONENT_SET (call once per variant). GRID layout is not allowed on slots. Requires Desktop Bridge.`,
+		`Create a SlotNode inside a component using createSlot(). Automatically creates a linked SLOT component property named after the slot (renaming the slot renames the property). Slots are freeform drop zones for instance content — more flexible than INSTANCE_SWAP. Works on standalone COMPONENTs and variant COMPONENTs inside a COMPONENT_SET (call once per variant). GRID layout is not allowed on slots. Requires Desktop Bridge.${FILE_KEY_DOC}`,
 		{
 			nodeId: z
 				.string()
@@ -52,8 +62,9 @@ export function registerSlotTools(
 				.enum(SLOT_LAYOUT_MODES)
 				.optional()
 				.describe("Auto-layout mode for the slot (GRID is not supported)"),
+			fileKey: fileKeySchema,
 		},
-		async ({ nodeId, name, width, height, layoutMode }) => {
+		async ({ nodeId, name, width, height, layoutMode, fileKey }) => {
 			try {
 				const connector = await getDesktopConnector();
 				const result = await connector.createSlot(nodeId, {
@@ -61,7 +72,7 @@ export function registerSlotTools(
 					width,
 					height,
 					layoutMode,
-				});
+				}, fileKey);
 
 				if (!result.success) {
 					throw new Error(result.error || "Failed to create slot");
@@ -99,16 +110,17 @@ export function registerSlotTools(
 
 	server.tool(
 		"figma_get_slots",
-		`List SlotNode children on a component, component set, or instance. Returns slot IDs, names, property keys, dimensions, and current child nodes. Use on instances before figma_append_to_slot to discover slot names/IDs.`,
+		`List SlotNode children on a component, component set, or instance. Returns slot IDs, names, property keys, dimensions, and current child nodes. Use on instances before figma_append_to_slot to discover slot names/IDs.${FILE_KEY_DOC}`,
 		{
 			nodeId: z
 				.string()
 				.describe("COMPONENT, COMPONENT_SET, or INSTANCE node ID"),
+			fileKey: fileKeySchema,
 		},
-		async ({ nodeId }) => {
+		async ({ nodeId, fileKey }) => {
 			try {
 				const connector = await getDesktopConnector();
-				const result = await connector.getSlots(nodeId);
+				const result = await connector.getSlots(nodeId, fileKey);
 
 				if (!result.success) {
 					throw new Error(result.error || "Failed to get slots");
@@ -142,7 +154,7 @@ export function registerSlotTools(
 
 	server.tool(
 		"figma_append_to_slot",
-		`Add content to a slot on a component instance. Clones sourceNodeId into the slot, or creates a new node (nodeType). SLOT content cannot be set via figma_set_instance_properties — use this tool instead. Widgets, stickies, and raw ComponentNodes cannot be appended to slots.`,
+		`Add content to a slot on a component instance. Clones sourceNodeId into the slot, or creates a new node (nodeType). SLOT content cannot be set via figma_set_instance_properties — use this tool instead. Widgets, stickies, and raw ComponentNodes cannot be appended to slots.${FILE_KEY_DOC}`,
 		{
 			slotId: z
 				.string()
@@ -178,6 +190,7 @@ export function registerSlotTools(
 				.optional()
 				.default(false)
 				.describe("Remove existing slot children before appending"),
+			fileKey: fileKeySchema,
 		},
 		async (args) => {
 			try {
@@ -188,8 +201,9 @@ export function registerSlotTools(
 					throw new Error("Provide sourceNodeId (clone into slot) or nodeType (create new content)");
 				}
 
+				const { fileKey, ...params } = args;
 				const connector = await getDesktopConnector();
-				const result = await connector.appendToSlot(args);
+				const result = await connector.appendToSlot(params, fileKey);
 
 				if (!result.success) {
 					throw new Error(result.error || "Failed to append to slot");
@@ -232,7 +246,7 @@ export function registerSlotTools(
 
 	server.tool(
 		"figma_reset_slot",
-		`Reset a slot on a component instance to its default (empty) state from the main component. Uses SlotNode.resetSlot().`,
+		`Reset a slot on a component instance to its default (empty) state from the main component. Uses SlotNode.resetSlot().${FILE_KEY_DOC}`,
 		{
 			slotId: z
 				.string()
@@ -246,15 +260,16 @@ export function registerSlotTools(
 				.string()
 				.optional()
 				.describe("Slot layer name on the instance"),
+			fileKey: fileKeySchema,
 		},
-		async ({ slotId, instanceId, slotName }) => {
+		async ({ slotId, instanceId, slotName, fileKey }) => {
 			try {
 				if (!slotId && !(instanceId && slotName)) {
 					throw new Error("Provide slotId OR (instanceId + slotName)");
 				}
 
 				const connector = await getDesktopConnector();
-				const result = await connector.resetSlot({ slotId, instanceId, slotName });
+				const result = await connector.resetSlot({ slotId, instanceId, slotName }, fileKey);
 
 				if (!result.success) {
 					throw new Error(result.error || "Failed to reset slot");
@@ -290,7 +305,7 @@ export function registerSlotTools(
 
 	server.tool(
 		"figma_add_slot_property",
-		`Manually add a SLOT component property and bind it to an existing frame (alternative to figma_create_slot). The frame must be a direct child of the component, must not use GRID layout, and must not be nested inside another slot. Supports description and preferredValues.`,
+		`Manually add a SLOT component property and bind it to an existing frame (alternative to figma_create_slot). The frame must be a direct child of the component, must not use GRID layout, and must not be nested inside another slot. Supports description and preferredValues.${FILE_KEY_DOC}`,
 		{
 			nodeId: z.string().describe("COMPONENT or COMPONENT_SET node ID"),
 			propertyName: z.string().describe("Slot property name (e.g. 'Content')"),
@@ -305,8 +320,9 @@ export function registerSlotTools(
 				.array(preferredValueSchema)
 				.optional()
 				.describe("Preferred components for slot content (SLOT-only)"),
+			fileKey: fileKeySchema,
 		},
-		async ({ nodeId, propertyName, frameNodeId, description, preferredValues }) => {
+		async ({ nodeId, propertyName, frameNodeId, description, preferredValues, fileKey }) => {
 			try {
 				const connector = await getDesktopConnector();
 				const code = `
@@ -341,7 +357,7 @@ const propKey = component.addComponentProperty(${JSON.stringify(propertyName)}, 
 frame.componentPropertyReferences = Object.assign({}, frame.componentPropertyReferences, { slotContentId: propKey });
 return { propertyKey: propKey, frameId: frame.id, frameName: frame.name };
 `;
-				const result = await connector.executeCodeViaUI(code, 10000);
+				const result = await connector.executeCodeViaUI(code, 10000, fileKey);
 
 				if (!result.success) {
 					throw new Error(result.error || "Failed to add slot property");

--- a/src/core/websocket-connector.ts
+++ b/src/core/websocket-connector.ts
@@ -299,12 +299,12 @@ export class WebSocketConnector implements IFigmaConnector {
   // Slot operations
   // ============================================================================
 
-  async createSlot(nodeId: string, options?: { name?: string; width?: number; height?: number; layoutMode?: string }): Promise<any> {
-    return this.wsServer.sendCommand('CREATE_SLOT', { nodeId, ...options });
+  async createSlot(nodeId: string, options?: { name?: string; width?: number; height?: number; layoutMode?: string }, fileKey?: string): Promise<any> {
+    return this.wsServer.sendCommand('CREATE_SLOT', { nodeId, ...options }, undefined, fileKey);
   }
 
-  async getSlots(nodeId: string): Promise<any> {
-    return this.wsServer.sendCommand('GET_SLOTS', { nodeId });
+  async getSlots(nodeId: string, fileKey?: string): Promise<any> {
+    return this.wsServer.sendCommand('GET_SLOTS', { nodeId }, undefined, fileKey);
   }
 
   async appendToSlot(params: {
@@ -316,12 +316,12 @@ export class WebSocketConnector implements IFigmaConnector {
     properties?: Record<string, string | number>;
     clone?: boolean;
     clearExisting?: boolean;
-  }): Promise<any> {
-    return this.wsServer.sendCommand('APPEND_TO_SLOT', params);
+  }, fileKey?: string): Promise<any> {
+    return this.wsServer.sendCommand('APPEND_TO_SLOT', params, undefined, fileKey);
   }
 
-  async resetSlot(params: { slotId?: string; instanceId?: string; slotName?: string }): Promise<any> {
-    return this.wsServer.sendCommand('RESET_SLOT', params);
+  async resetSlot(params: { slotId?: string; instanceId?: string; slotName?: string }, fileKey?: string): Promise<any> {
+    return this.wsServer.sendCommand('RESET_SLOT', params, undefined, fileKey);
   }
 
   // ============================================================================

--- a/tests/slot-tools.test.ts
+++ b/tests/slot-tools.test.ts
@@ -108,11 +108,29 @@ describe("registerSlotTools", () => {
 			width: 320,
 			height: 200,
 			layoutMode: "VERTICAL",
-		});
+		}, undefined);
 		expect(result.isError).toBeUndefined();
 		const payload = JSON.parse(result.content[0].text);
 		expect(payload.success).toBe(true);
 		expect(payload.slot.name).toBe("Content");
+	});
+
+	test("figma_create_slot threads fileKey through to the connector", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		await server._getTool("figma_create_slot").handler({
+			nodeId: "1:2",
+			name: "Content",
+			fileKey: "abc123",
+		});
+
+		expect(connector.createSlot).toHaveBeenCalledWith(
+			"1:2",
+			expect.objectContaining({ name: "Content" }),
+			"abc123",
+		);
 	});
 
 	test("figma_get_slots returns slot list", async () => {
@@ -121,10 +139,19 @@ describe("registerSlotTools", () => {
 		registerSlotTools(server as never, async () => connector);
 
 		const result = await server._getTool("figma_get_slots").handler({ nodeId: "1:2" });
-		expect(connector.getSlots).toHaveBeenCalledWith("1:2");
+		expect(connector.getSlots).toHaveBeenCalledWith("1:2", undefined);
 		const payload = JSON.parse(result.content[0].text);
 		expect(payload.count).toBe(1);
 		expect(payload.slots[0].name).toBe("Content");
+	});
+
+	test("figma_get_slots threads fileKey through to the connector", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		await server._getTool("figma_get_slots").handler({ nodeId: "1:2", fileKey: "abc123" });
+		expect(connector.getSlots).toHaveBeenCalledWith("1:2", "abc123");
 	});
 
 	test("figma_append_to_slot requires slot target and content source", async () => {
@@ -159,8 +186,26 @@ describe("registerSlotTools", () => {
 				sourceNodeId: "1:99",
 				clearExisting: true,
 			}),
+			undefined,
 		);
 		expect(result.isError).toBeUndefined();
+	});
+
+	test("figma_append_to_slot threads fileKey through to the connector, stripped from params", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		await server._getTool("figma_append_to_slot").handler({
+			slotId: "1:10",
+			sourceNodeId: "1:99",
+			fileKey: "abc123",
+		});
+
+		expect(connector.appendToSlot).toHaveBeenCalledWith(
+			expect.not.objectContaining({ fileKey: expect.anything() }),
+			"abc123",
+		);
 	});
 
 	test("figma_reset_slot resolves by instanceId + slotName", async () => {
@@ -176,7 +221,24 @@ describe("registerSlotTools", () => {
 		expect(connector.resetSlot).toHaveBeenCalledWith({
 			instanceId: "1:2",
 			slotName: "Content",
+		}, undefined);
+	});
+
+	test("figma_reset_slot threads fileKey through to the connector", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		await server._getTool("figma_reset_slot").handler({
+			instanceId: "1:2",
+			slotName: "Content",
+			fileKey: "abc123",
 		});
+
+		expect(connector.resetSlot).toHaveBeenCalledWith(
+			{ slotId: undefined, instanceId: "1:2", slotName: "Content" },
+			"abc123",
+		);
 	});
 
 	test("figma_add_slot_property executes binding code", async () => {
@@ -196,6 +258,25 @@ describe("registerSlotTools", () => {
 		expect(payload.success).toBe(true);
 		expect(payload.result.propertyKey).toBe("Content#1:10");
 	});
+
+	test("figma_add_slot_property threads fileKey through to executeCodeViaUI", async () => {
+		const server = createMockServer();
+		const connector = createMockConnector();
+		registerSlotTools(server as never, async () => connector);
+
+		await server._getTool("figma_add_slot_property").handler({
+			nodeId: "1:2",
+			propertyName: "Content",
+			frameNodeId: "1:5",
+			fileKey: "abc123",
+		});
+
+		expect(connector.executeCodeViaUI).toHaveBeenCalledWith(
+			expect.any(String),
+			10000,
+			"abc123",
+		);
+	});
 });
 
 describe("WebSocket slot commands", () => {
@@ -211,18 +292,95 @@ describe("WebSocket slot commands", () => {
 		expect(mockServer.sendCommand).toHaveBeenCalledWith("CREATE_SLOT", {
 			nodeId: "1:2",
 			name: "Content",
-		});
+		}, undefined, undefined);
 
 		await connector.getSlots("1:2");
-		expect(mockServer.sendCommand).toHaveBeenCalledWith("GET_SLOTS", { nodeId: "1:2" });
+		expect(mockServer.sendCommand).toHaveBeenCalledWith("GET_SLOTS", { nodeId: "1:2" }, undefined, undefined);
 
 		await connector.appendToSlot({ slotId: "1:10", sourceNodeId: "1:99" });
 		expect(mockServer.sendCommand).toHaveBeenCalledWith("APPEND_TO_SLOT", {
 			slotId: "1:10",
 			sourceNodeId: "1:99",
-		});
+		}, undefined, undefined);
 
 		await connector.resetSlot({ slotId: "1:10" });
-		expect(mockServer.sendCommand).toHaveBeenCalledWith("RESET_SLOT", { slotId: "1:10" });
+		expect(mockServer.sendCommand).toHaveBeenCalledWith("RESET_SLOT", { slotId: "1:10" }, undefined, undefined);
+	});
+
+	test("connector routes slot methods to a specific fileKey via sendCommand's targetFileKey", async () => {
+		const { WebSocketConnector } = await import("../src/core/websocket-connector");
+		const mockServer = {
+			isClientConnected: () => false,
+			sendCommand: jest.fn().mockResolvedValue({ success: true }),
+		};
+		const connector = new WebSocketConnector(mockServer as never);
+
+		await connector.createSlot("1:2", { name: "Content" }, "file-a");
+		expect(mockServer.sendCommand).toHaveBeenCalledWith(
+			"CREATE_SLOT",
+			{ nodeId: "1:2", name: "Content" },
+			undefined,
+			"file-a",
+		);
+
+		await connector.getSlots("1:2", "file-a");
+		expect(mockServer.sendCommand).toHaveBeenCalledWith("GET_SLOTS", { nodeId: "1:2" }, undefined, "file-a");
+
+		await connector.appendToSlot({ slotId: "1:10", sourceNodeId: "1:99" }, "file-a");
+		expect(mockServer.sendCommand).toHaveBeenCalledWith(
+			"APPEND_TO_SLOT",
+			{ slotId: "1:10", sourceNodeId: "1:99" },
+			undefined,
+			"file-a",
+		);
+
+		await connector.resetSlot({ slotId: "1:10" }, "file-a");
+		expect(mockServer.sendCommand).toHaveBeenCalledWith("RESET_SLOT", { slotId: "1:10" }, undefined, "file-a");
+	});
+});
+
+describe("Cloud Mode slot commands reject fileKey", () => {
+	test("createSlot/getSlots/appendToSlot/resetSlot reject a passed fileKey", async () => {
+		const { CloudWebSocketConnector } = await import("../src/core/cloud-websocket-connector");
+		const stub = {
+			fetch: jest.fn().mockResolvedValue(
+				new Response(JSON.stringify({ result: { success: true } }), {
+					headers: { "Content-Type": "application/json" },
+				}),
+			),
+		};
+		const connector = new CloudWebSocketConnector(stub as never);
+
+		// Cloud Mode pairs with exactly one plugin instance. Honoring the call
+		// as-if-targeted would report a successful write to the wrong file.
+		await expect(connector.createSlot("1:2", {}, "some-other-file-key")).rejects.toThrow(
+			"Per-file targeting (fileKey) is Local Mode only",
+		);
+		await expect(connector.getSlots("1:2", "some-other-file-key")).rejects.toThrow(
+			"Per-file targeting (fileKey) is Local Mode only",
+		);
+		await expect(
+			connector.appendToSlot({ slotId: "1:10" }, "some-other-file-key"),
+		).rejects.toThrow("Per-file targeting (fileKey) is Local Mode only");
+		await expect(
+			connector.resetSlot({ slotId: "1:10" }, "some-other-file-key"),
+		).rejects.toThrow("Per-file targeting (fileKey) is Local Mode only");
+
+		expect(stub.fetch).not.toHaveBeenCalled();
+	});
+
+	test("createSlot/getSlots/appendToSlot/resetSlot still work when fileKey is omitted", async () => {
+		const { CloudWebSocketConnector } = await import("../src/core/cloud-websocket-connector");
+		const stub = {
+			fetch: jest.fn().mockResolvedValue(
+				new Response(JSON.stringify({ result: { success: true } }), {
+					headers: { "Content-Type": "application/json" },
+				}),
+			),
+		};
+		const connector = new CloudWebSocketConnector(stub as never);
+
+		await expect(connector.createSlot("1:2", {})).resolves.toEqual({ success: true });
+		expect(stub.fetch).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Hi TJ. been working a bit more and asked my agent for where the biggest pains where in working in multiple files at once. It said the `fileKey` param that was added in #107 should also be added to slot tools.

*(Everything below this line was written by Claude based on the actual diff — flagging that up front.)*

## Problem
`figma_execute` (#107) can already target a specific connected file via `fileKey` without touching the active file or target lock, but the Figma Slots tool family (`figma_create_slot`, `figma_get_slots`, `figma_append_to_slot`, `figma_reset_slot`, `figma_add_slot_property`) never got the same treatment — they always operate on the active file. In practice this forces a `figma_navigate({ url, lock: true })` before every per-file batch of slot calls, then an unlock after, which is fully serial by construction and leaves a window where a reconnect between the navigate and the slot calls can silently move the active file mid-sequence. A real workflow driving ~12 `figma_create_slot` calls per component across 6 files hit this directly — the per-file switch+lock/unlock cycle was the single biggest source of wall-clock slowdown in that session.

## Changes
- `figma_create_slot`, `figma_get_slots`, `figma_append_to_slot`, `figma_reset_slot`, and `figma_add_slot_property` all gain an optional `fileKey` param, documented the same way `figma_execute`'s is.
- `IFigmaConnector.createSlot/getSlots/appendToSlot/resetSlot` take a trailing optional `fileKey`, forwarded through `WebSocketConnector` to `FigmaWebSocketServer.sendCommand`'s existing `targetFileKey` argument — no changes needed there, PR #107 already built that routing.
- `CloudWebSocketConnector` rejects a passed `fileKey` on all four slot methods with the same explicit error `executeCodeViaUI` uses (`rejectFileKey` helper) — the cloud relay pairs with exactly one plugin instance, so silently running against the paired file instead would misroute writes without any way for the caller to detect it.
- `figma_add_slot_property` (implemented via `executeCodeViaUI` directly) threads `fileKey` straight through, same as `figma_execute` itself.

Transport, target lock, and port-discovery are unchanged — this is additive at the tool/connector layer only, same shape as #107.

## Testing
- Extended `tests/slot-tools.test.ts`: a dedicated `fileKey`-passthrough test per tool (5 tools), a `WebSocketConnector` test confirming `fileKey` lands as `sendCommand`'s `targetFileKey` for all four slot methods, and `CloudWebSocketConnector` tests confirming a passed `fileKey` is rejected (never reaches `fetch`) while omitting it still works normally — mirrors the `write-tools.test.ts` extension pattern from #107.
- Full suite passes: 52 suites / 1460 tests. `tsc --noEmit` clean.

No breaking changes — `fileKey` is optional everywhere and existing calls are byte-identical.
