### PR TITLE
fix: exit local server when stdin closes

### DIFF
--- a/src/core/local-process-lifecycle.ts
+++ b/src/core/local-process-lifecycle.ts
@@ -1,0 +1,79 @@
+/**
+ * Process lifecycle wiring for the local stdio MCP server.
+ *
+ * MCP clients communicate with the server through stdin/stdout. Closing that
+ * transport produces stdin EOF, but does not necessarily send an OS signal.
+ * Treat both stdin terminal events as normal shutdown requests so the
+ * WebSocket bridge and its advertised port are released promptly.
+ */
+
+interface EventSource {
+	on(event: string, listener: () => void): unknown;
+}
+
+interface UnrefableTimer {
+	unref?: () => void;
+}
+
+export interface LocalProcessLifecycleOptions {
+	shutdown: () => Promise<void>;
+	stdin?: EventSource;
+	processEvents?: EventSource;
+	exit?: (code: number) => void;
+	shutdownTimeoutMs?: number;
+	onShutdownTimeout?: (timeoutMs: number) => void;
+	onShutdownError?: (error: unknown) => void;
+}
+
+/**
+ * Register all terminal conditions for the local MCP process.
+ *
+ * The returned function lets tests and callers initiate the same idempotent
+ * shutdown path directly.
+ */
+export function registerLocalProcessLifecycle(
+	options: LocalProcessLifecycleOptions,
+): (code?: number) => Promise<void> {
+	const {
+		shutdown,
+		stdin = process.stdin,
+		processEvents = process,
+		exit = (code) => process.exit(code),
+		shutdownTimeoutMs = 5000,
+		onShutdownTimeout,
+		onShutdownError,
+	} = options;
+
+	let shuttingDown = false;
+
+	const gracefulExit = async (code = 0): Promise<void> => {
+		if (shuttingDown) return;
+		shuttingDown = true;
+
+		const backstop = setTimeout(() => {
+			onShutdownTimeout?.(shutdownTimeoutMs);
+			exit(code);
+		}, shutdownTimeoutMs);
+		(backstop as unknown as UnrefableTimer).unref?.();
+
+		try {
+			await shutdown();
+		} catch (error) {
+			onShutdownError?.(error);
+		}
+
+		clearTimeout(backstop);
+		exit(code);
+	};
+
+	const requestNormalExit = () => {
+		void gracefulExit(0);
+	};
+
+	processEvents.on("SIGINT", requestNormalExit);
+	processEvents.on("SIGTERM", requestNormalExit);
+	stdin.on("end", requestNormalExit);
+	stdin.on("close", requestNormalExit);
+
+	return gracefulExit;
+}

--- a/src/local.ts
+++ b/src/local.ts
@@ -70,6 +70,7 @@ import {
 import { registerFigJamTools } from "./core/figjam-tools.js";
 import { registerSlidesTools } from "./core/slides-tools.js";
 import { registerSlotTools } from "./core/slot-tools.js";
+import { registerLocalProcessLifecycle } from "./core/local-process-lifecycle.js";
 
 const logger = createChildLogger({ component: "local-server" });
 
@@ -4068,31 +4069,18 @@ Without libraryFileKey/libraryFileUrl, searches the currently open file (local c
 async function main() {
 	const server = new LocalFigmaConsoleMCP();
 
-	// Handle graceful shutdown. A hard backstop guarantees the process exits even
-	// if shutdown() hangs (e.g. an HTTP/WebSocket close that blocks on a lingering
-	// connection). Without this, the SIGTERM listener suppresses Node's default
-	// terminate-on-SIGTERM and the process zombifies — holding its port forever.
-	const SHUTDOWN_TIMEOUT_MS = 5000;
-	let shuttingDown = false;
-	const gracefulExit = async (code: number) => {
-		if (shuttingDown) return;
-		shuttingDown = true;
-		const backstop = setTimeout(() => {
-			logger.error(`Shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms — forcing exit`);
-			process.exit(code);
-		}, SHUTDOWN_TIMEOUT_MS);
-		backstop.unref();
-		try {
-			await server.shutdown();
-		} catch (error) {
+	// Handle both OS signals and stdio transport closure. MCP clients commonly
+	// close stdin without sending a signal; treating EOF as a terminal condition
+	// prevents the still-live WebSocket bridge from orphaning this process.
+	registerLocalProcessLifecycle({
+		shutdown: () => server.shutdown(),
+		onShutdownTimeout: (timeoutMs) => {
+			logger.error(`Shutdown exceeded ${timeoutMs}ms — forcing exit`);
+		},
+		onShutdownError: (error) => {
 			logger.error({ error }, "Error during shutdown");
-		}
-		clearTimeout(backstop);
-		process.exit(code);
-	};
-
-	process.on("SIGINT", () => { void gracefulExit(0); });
-	process.on("SIGTERM", () => { void gracefulExit(0); });
+		},
+	});
 
 	// Start the server
 	await server.start();

--- a/tests/local-process-lifecycle.test.ts
+++ b/tests/local-process-lifecycle.test.ts
@@ -1,0 +1,195 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { existsSync, unlinkSync } from "node:fs";
+import { createServer } from "node:net";
+import { join } from "node:path";
+import { registerLocalProcessLifecycle } from "../src/core/local-process-lifecycle.js";
+import { getPortFilePath } from "../src/core/port-discovery.js";
+
+const flushPromises = () =>
+	new Promise<void>((resolve) => setImmediate(resolve));
+
+describe("local process lifecycle", () => {
+	for (const terminalEvent of ["SIGINT", "SIGTERM", "end", "close"] as const) {
+		it(`shuts down and exits on ${terminalEvent}`, async () => {
+			const stdin = new EventEmitter();
+			const processEvents = new EventEmitter();
+			const shutdown = jest.fn().mockResolvedValue(undefined);
+			const exit = jest.fn();
+
+			registerLocalProcessLifecycle({ shutdown, stdin, processEvents, exit });
+			(terminalEvent === "end" || terminalEvent === "close"
+				? stdin
+				: processEvents
+			).emit(terminalEvent);
+			await flushPromises();
+
+			expect(shutdown).toHaveBeenCalledTimes(1);
+			expect(exit).toHaveBeenCalledTimes(1);
+			expect(exit).toHaveBeenCalledWith(0);
+		});
+	}
+
+	it("coalesces repeated terminal events into one shutdown", async () => {
+		const stdin = new EventEmitter();
+		const processEvents = new EventEmitter();
+		const shutdown = jest.fn().mockResolvedValue(undefined);
+		const exit = jest.fn();
+
+		registerLocalProcessLifecycle({ shutdown, stdin, processEvents, exit });
+		stdin.emit("end");
+		stdin.emit("close");
+		processEvents.emit("SIGTERM");
+		await flushPromises();
+
+		expect(shutdown).toHaveBeenCalledTimes(1);
+		expect(exit).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports shutdown errors and still exits", async () => {
+		const stdin = new EventEmitter();
+		const processEvents = new EventEmitter();
+		const error = new Error("shutdown failed");
+		const onShutdownError = jest.fn();
+		const exit = jest.fn();
+
+		registerLocalProcessLifecycle({
+			shutdown: jest.fn().mockRejectedValue(error),
+			stdin,
+			processEvents,
+			exit,
+			onShutdownError,
+		});
+		stdin.emit("end");
+		await flushPromises();
+
+		expect(onShutdownError).toHaveBeenCalledWith(error);
+		expect(exit).toHaveBeenCalledWith(0);
+	});
+
+	it("forces exit when shutdown exceeds the deadline", async () => {
+		jest.useFakeTimers();
+		try {
+			const stdin = new EventEmitter();
+			const processEvents = new EventEmitter();
+			const exit = jest.fn();
+			const onShutdownTimeout = jest.fn();
+
+			registerLocalProcessLifecycle({
+				shutdown: () => new Promise<void>(() => undefined),
+				stdin,
+				processEvents,
+				exit,
+				shutdownTimeoutMs: 25,
+				onShutdownTimeout,
+			});
+			stdin.emit("close");
+			jest.advanceTimersByTime(25);
+
+			expect(onShutdownTimeout).toHaveBeenCalledWith(25);
+			expect(exit).toHaveBeenCalledWith(0);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+});
+
+const repoRoot = process.cwd();
+
+async function reservePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				server.close();
+				reject(new Error("Failed to reserve a TCP port"));
+				return;
+			}
+			const port = address.port;
+			server.close((error) => (error ? reject(error) : resolve(port)));
+		});
+	});
+}
+
+async function waitFor(
+	predicate: () => boolean,
+	timeoutMs: number,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error(`Condition not met within ${timeoutMs}ms`);
+}
+
+async function waitForExit(
+	child: ChildProcess,
+	timeoutMs: number,
+): Promise<number | null> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(
+			() => reject(new Error(`Child did not exit within ${timeoutMs}ms`)),
+			timeoutMs,
+		);
+		child.once("exit", (code) => {
+			clearTimeout(timer);
+			resolve(code);
+		});
+	});
+}
+
+describe("local server stdin EOF integration", () => {
+	jest.setTimeout(30_000);
+
+	it("exits and releases its advertised port when stdin closes", async () => {
+		const port = await reservePort();
+		const portFile = getPortFilePath(port);
+		const tsxCli = require.resolve("tsx/cli");
+		let child: ChildProcess | undefined;
+		let stderr = "";
+
+		try {
+			child = spawn(
+				process.execPath,
+				[tsxCli, join(repoRoot, "src", "local.ts")],
+				{
+					cwd: repoRoot,
+					env: { ...process.env, FIGMA_WS_PORT: String(port) },
+					stdio: ["pipe", "pipe", "pipe"],
+				},
+			);
+			child.stderr?.on("data", (chunk) => {
+				stderr += chunk.toString();
+			});
+
+			await waitFor(() => existsSync(portFile), 15_000);
+			child.stdin?.end();
+
+			const exitCode = await waitForExit(child, 7_000);
+			expect(exitCode).toBe(0);
+			expect(existsSync(portFile)).toBe(false);
+
+			await new Promise<void>((resolve, reject) => {
+				const probe = createServer();
+				probe.once("error", reject);
+				probe.listen(port, "127.0.0.1", () =>
+					probe.close((error) => (error ? reject(error) : resolve())),
+				);
+			});
+		} catch (error) {
+			throw new Error(
+				`${error instanceof Error ? error.message : String(error)}\nChild stderr:\n${stderr}`,
+			);
+		} finally {
+			if (child && child.exitCode === null) child.kill("SIGKILL");
+			try {
+				if (existsSync(portFile)) unlinkSync(portFile);
+			} catch {
+				/* best-effort */
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Add centralized lifecycle handling for the local MCP server.
- Gracefully shut down when stdin closes or reaches EOF.
- Prevent orphaned processes and ensure the WebSocket port is released.
- Add unit and integration tests for signals, stdin events, shutdown errors, and timeouts.

## Testing

- `npm test -- --runInBand tests/local-process-lifecycle.test.ts`
- `npm run build:local`