### PR TITLE
feat: support inserting local images into Figma

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -91,7 +91,7 @@ This guide provides detailed documentation for each tool, including when to use 
 | | `figma_set_fills` | Set fill colors | Local / Cloud |
 | | `figma_set_strokes` | Set stroke colors | Local / Cloud |
 | | `figma_create_child` | Create child node | Local / Cloud |
-| **🖼️ Image** | `figma_set_image_fill` | Set image fill on nodes | Local / Cloud |
+| **🖼️ Image** | `figma_set_image_fill` | Insert a local image or set an image fill | Local / Cloud |
 | **🔍 Accessibility** | `figma_lint_design` | 14 WCAG checks with AA/best-practice level tagging | Local / Cloud |
 | | `figma_audit_component_accessibility` | Deep component scorecard: states, focus, color-blind simulation | Local / Cloud |
 | | `figma_scan_code_accessibility` | Scan HTML with axe-core (104 rules): ARIA, labels, landmarks, semantics | Local / Cloud |
@@ -2867,25 +2867,33 @@ figma_get_annotation_categories()
 
 ### `figma_set_image_fill`
 
-Set an image fill on one or more Figma nodes. Accepts base64-encoded image data or (in Local Mode) an absolute file path.
+Insert a PNG/JPEG/GIF into Figma, or set an image fill on existing nodes. Accepts base64-encoded image data or (in Local Mode) an absolute file path, including Windows paths.
+
+Clipboard paste is not supported — pass a file path or base64.
 
 **Mode:** Local / Cloud
 
 **When to Use:**
+- Pasting a local photo, illustration, or screenshot onto the current page
 - Applying photos, illustrations, or textures to frames and shapes
 - Setting hero images, avatars, or background images
 - Replacing placeholder images with real assets
 
 **Usage:**
 ```javascript
-// Base64 image data
+// Insert a local file as a new layer (Local Mode) — omit nodeIds
+figma_set_image_fill({
+  imageData: "C:\\Users\\me\\Pictures\\hero.png"
+})
+
+// Base64 image data applied to existing nodes
 figma_set_image_fill({
   nodeIds: ["123:456", "789:012"],
   imageData: "iVBORw0KGgo...",  // base64-encoded PNG or JPEG
   scaleMode: "FILL"
 })
 
-// File path (Local Mode only)
+// File path on an existing node (Local Mode only)
 figma_set_image_fill({
   nodeIds: ["123:456"],
   imageData: "/tmp/hero-image.jpg",
@@ -2894,14 +2902,16 @@ figma_set_image_fill({
 ```
 
 **Parameters:**
-- `nodeIds` (required): Array of node IDs to apply the image fill to
-- `imageData` (required): Base64-encoded image data (JPEG/PNG), or an absolute file path starting with `/` (Local Mode only)
+- `nodeIds` (optional): Array of node IDs to apply the image fill to. Omit or pass `[]` to insert a new image-sized rectangle on the current page.
+- `imageData` (required): Base64-encoded PNG/JPEG/GIF (optionally a `data:image/...;base64` URL), or an absolute local file path (Local Mode only).
 - `scaleMode` (optional): How the image fills the node — `"FILL"` (default), `"FIT"`, `"CROP"`, or `"TILE"`
+- `name` (optional): Layer name for a newly created image. Defaults to the file name when `imageData` is a path.
 
 **Returns:**
 - `imageHash`: Figma's internal hash for the created image
 - `updatedCount`: Number of nodes successfully updated
-- `nodes`: Array of updated node IDs and names
+- `nodes`: Array of updated/created node IDs and names (`created: true` when a new layer was inserted)
+- `created`: `true` when a new image node was inserted
 
 ---
 

--- a/figma-desktop-bridge/code.js
+++ b/figma-desktop-bridge/code.js
@@ -3281,27 +3281,54 @@ figma.ui.onmessage = async (msg) => {
         imageHash: imageHash
       };
 
-      // Resolve target nodes
+      // Resolve target nodes. Empty nodeIds = insert a new rectangle sized to the image.
       var nodeIds = msg.nodeIds || (msg.nodeId ? [msg.nodeId] : []);
+      if (!Array.isArray(nodeIds)) {
+        nodeIds = [nodeIds];
+      }
       var updatedCount = 0;
       var updatedNodes = [];
       var skipWarnings = [];
 
-      for (var i = 0; i < nodeIds.length; i++) {
-        var node = await figma.getNodeByIdAsync(nodeIds[i]);
-        if (!node) {
-          skipWarnings.push('node "' + nodeIds[i] + '" not found');
-        } else if (!('fills' in node)) {
-          skipWarnings.push('node "' + nodeIds[i] + '" (' + node.type + ') does not support fills');
-        } else {
-          node.fills = [fill];
-          updatedCount++;
-          updatedNodes.push({ id: node.id, name: node.name });
+      if (nodeIds.length === 0) {
+        var size = await image.getSizeAsync();
+        var rect = figma.createRectangle();
+        rect.name = msg.name || 'Image';
+        rect.resize(size.width, size.height);
+        rect.fills = [fill];
+        var center = figma.viewport.center;
+        rect.x = center.x - size.width / 2;
+        rect.y = center.y - size.height / 2;
+        figma.currentPage.selection = [rect];
+        figma.viewport.scrollAndZoomIntoView([rect]);
+        updatedCount = 1;
+        updatedNodes.push({
+          id: rect.id,
+          name: rect.name,
+          created: true,
+          width: size.width,
+          height: size.height
+        });
+      } else {
+        for (var i = 0; i < nodeIds.length; i++) {
+          var node = await figma.getNodeByIdAsync(nodeIds[i]);
+          if (!node) {
+            skipWarnings.push('node "' + nodeIds[i] + '" not found');
+          } else if (!('fills' in node)) {
+            skipWarnings.push('node "' + nodeIds[i] + '" (' + node.type + ') does not support fills');
+          } else {
+            node.fills = [fill];
+            updatedCount++;
+            updatedNodes.push({ id: node.id, name: node.name });
+          }
         }
       }
 
-      if (updatedCount === 0 && nodeIds.length > 0) {
-        throw new Error('Image fill applied to 0 node(s): ' + skipWarnings.join('; '));
+      if (updatedCount === 0) {
+        throw new Error(
+          'Image fill applied to 0 node(s)' +
+          (skipWarnings.length ? ': ' + skipWarnings.join('; ') : '. Pass nodeIds to update existing layers, or omit nodeIds to insert a new image on the page.')
+        );
       }
 
       console.log('🌉 [Desktop Bridge] Image fill applied to', updatedCount, 'node(s), hash:', imageHash);

--- a/figma-desktop-bridge/ui.html
+++ b/figma-desktop-bridge/ui.html
@@ -945,19 +945,38 @@
     };
 
     // Set image fill on nodes — decodes base64 in browser context (atob available here)
-    // then sends raw bytes to plugin where figma.createImage() is called
-    window.setImageFill = (nodeIds, imageData, scaleMode) => {
-      // Decode base64 to Uint8Array in browser context where atob() is available
-      var binaryStr = atob(imageData);
+    // then sends raw bytes to plugin where figma.createImage() is called.
+    // Empty nodeIds inserts a new image-sized rectangle on the current page.
+    window.setImageFill = (nodeIds, imageData, scaleMode, name) => {
+      if (!imageData || typeof imageData !== 'string') {
+        return Promise.resolve({ success: false, error: 'imageData is required' });
+      }
+      var payload = imageData;
+      var dataUrlMarker = payload.indexOf('base64,');
+      if (payload.slice(0, 5).toLowerCase() === 'data:' && dataUrlMarker !== -1) {
+        payload = payload.slice(dataUrlMarker + 7);
+      }
+      payload = payload.replace(/\s/g, '');
+      var binaryStr;
+      try {
+        binaryStr = atob(payload);
+      } catch (err) {
+        return Promise.resolve({
+          success: false,
+          error: 'imageData is not valid base64. Pass PNG/JPEG/GIF bytes as base64, or in Local Mode an absolute file path. Clipboard paste is not supported.'
+        });
+      }
       var bytes = new Uint8Array(binaryStr.length);
       for (var i = 0; i < binaryStr.length; i++) {
         bytes[i] = binaryStr.charCodeAt(i);
       }
+      var ids = Array.isArray(nodeIds) ? nodeIds : (nodeIds ? [nodeIds] : []);
       // Send as plain Array (postMessage can't always transfer typed arrays cleanly)
       return window.sendPluginCommand('SET_IMAGE_FILL', {
-        nodeIds: Array.isArray(nodeIds) ? nodeIds : [nodeIds],
+        nodeIds: ids,
         imageBytes: Array.from(bytes),
-        scaleMode: scaleMode || 'FILL'
+        scaleMode: scaleMode || 'FILL',
+        name: name
       }, 60000)
         .catch(function(err) { return { success: false, error: err.message || String(err) }; });
     };
@@ -1111,7 +1130,7 @@
         'SET_TEXT_CONTENT': function(params) { return window.setTextContent(params.nodeId, params.text, params); },
         'CREATE_CHILD_NODE': function(params) { return window.createChildNode(params.parentId, params.nodeType, params.properties); },
         'CAPTURE_SCREENSHOT': function(params) { return window.captureScreenshot(params.nodeId, params); },
-        'SET_IMAGE_FILL': function(params) { return window.setImageFill(params.nodeIds || params.nodeId, params.imageData, params.scaleMode); },
+        'SET_IMAGE_FILL': function(params) { return window.setImageFill(params.nodeIds || params.nodeId, params.imageData, params.scaleMode, params.name); },
         'SET_INSTANCE_PROPERTIES': function(params) { return window.setInstanceProperties(params.nodeId, params.properties); },
         'LINT_DESIGN': function(params) { return window.lintDesign(params.nodeId, params.rules, params.maxDepth, params.maxFindings); },
         'AUDIT_COMPONENT_ACCESSIBILITY': function(params) { return window.auditComponentAccessibility(params.nodeId, params.targetSize); },

--- a/src/core/cloud-websocket-connector.ts
+++ b/src/core/cloud-websocket-connector.ts
@@ -368,8 +368,14 @@ export class CloudWebSocketConnector implements IFigmaConnector {
 	// Image fill
 	// ============================================================================
 
-	async setImageFill(nodeIds: string[], imageData: string, scaleMode = 'FILL'): Promise<any> {
-		return this.sendCommand('SET_IMAGE_FILL', { nodeIds, imageData, scaleMode }, 60000);
+	async setImageFill(nodeIds: string[], imageData: string, scaleMode = 'FILL', name?: string): Promise<any> {
+		const params: { nodeIds: string[]; imageData: string; scaleMode: string; name?: string } = {
+			nodeIds,
+			imageData,
+			scaleMode,
+		};
+		if (name) params.name = name;
+		return this.sendCommand('SET_IMAGE_FILL', params, 60000);
 	}
 
 	// ============================================================================

--- a/src/core/figma-connector.ts
+++ b/src/core/figma-connector.ts
@@ -88,7 +88,7 @@ export interface IFigmaConnector {
   setInstanceProperties(nodeId: string, properties: any): Promise<any>;
 
   // Image fill
-  setImageFill(nodeIds: string[], imageData: string, scaleMode?: string): Promise<any>;
+  setImageFill(nodeIds: string[], imageData: string, scaleMode?: string, name?: string): Promise<any>;
 
   // Design lint
   lintDesign(nodeId?: string, rules?: string[], maxDepth?: number, maxFindings?: number): Promise<any>;

--- a/src/core/image-input.ts
+++ b/src/core/image-input.ts
@@ -1,0 +1,124 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Figma's `createImage` accepts PNG, JPEG, and GIF only. */
+const IMAGE_EXT = /\.(png|jpe?g|gif)$/i;
+
+/** Keep websocket payloads bounded; Figma also rejects very large images. */
+export const MAX_IMAGE_BYTES = 15 * 1024 * 1024;
+
+export type ResolvedImageInput = {
+	base64: string;
+	source: "base64" | "data-url" | "file";
+	filePath?: string;
+	name?: string;
+};
+
+/**
+ * True when `value` is a filesystem path (or file URL) to a PNG/JPEG/GIF —
+ * including Windows paths (`C:\...`) and `file://` URLs.
+ *
+ * JPEG base64 starts with `/9j/` and has no filename extension, so it is not
+ * treated as a path. PNG base64 (`iVBORw0KGgo...`) also has no extension.
+ */
+export function looksLikeImageFilePath(value: string): boolean {
+	const s = stripWrappingQuotes(value.trim());
+	if (!s || /^data:/i.test(s)) return false;
+	if (/^file:/i.test(s)) return true;
+	return IMAGE_EXT.test(pathWithoutQuery(s));
+}
+
+/**
+ * Normalize tool input into raw base64 for the Desktop Bridge.
+ * Reads local files in Local Mode; Cloud Mode cannot see the user's disk.
+ */
+export function resolveImageInput(imageData: string): ResolvedImageInput {
+	if (typeof imageData !== "string" || !imageData.trim()) {
+		throw new Error(
+			"imageData is required. Pass an absolute PNG/JPEG/GIF file path (Local Mode) or base64-encoded image bytes.",
+		);
+	}
+
+	const trimmed = stripWrappingQuotes(imageData.trim());
+
+	const dataUrl = /^data:image\/[a-zA-Z0-9+.-]+;base64,([\s\S]+)$/i.exec(
+		trimmed,
+	);
+	if (dataUrl) {
+		return { base64: dataUrl[1].replace(/\s/g, ""), source: "data-url" };
+	}
+
+	if (looksLikeImageFilePath(trimmed)) {
+		return readImageFile(trimmed);
+	}
+
+	return { base64: trimmed.replace(/\s/g, ""), source: "base64" };
+}
+
+function stripWrappingQuotes(value: string): string {
+	if (
+		(value.startsWith('"') && value.endsWith('"')) ||
+		(value.startsWith("'") && value.endsWith("'"))
+	) {
+		return value.slice(1, -1);
+	}
+	return value;
+}
+
+function pathWithoutQuery(value: string): string {
+	return value.split(/[?#]/)[0];
+}
+
+function readImageFile(rawPath: string): ResolvedImageInput {
+	let filePath = rawPath;
+
+	if (/^file:/i.test(filePath)) {
+		try {
+			filePath = fileURLToPath(filePath);
+		} catch {
+			throw new Error(`Invalid file URL: ${rawPath}`);
+		}
+	}
+
+	if (filePath.startsWith("~")) {
+		const home = process.env.USERPROFILE || process.env.HOME;
+		if (home) {
+			filePath = home + filePath.slice(1);
+		}
+	}
+
+	let exists = false;
+	try {
+		exists = existsSync(filePath);
+	} catch {
+		exists = false;
+	}
+
+	if (!exists) {
+		throw new Error(
+			`Image file not found: ${filePath}. File paths only work in Local Mode (the MCP server must run on the same machine as the file). In Cloud Mode, pass base64 PNG/JPEG data instead. Clipboard paste is not supported.`,
+		);
+	}
+
+	const ext = extname(filePath);
+	if (!IMAGE_EXT.test(ext)) {
+		throw new Error(
+			`Unsupported image type "${ext || "(none)"}". Figma accepts PNG, JPEG, or GIF.`,
+		);
+	}
+
+	const stat = statSync(filePath);
+	if (stat.size > MAX_IMAGE_BYTES) {
+		throw new Error(
+			`Image is too large (${Math.round(stat.size / (1024 * 1024))}MB). Maximum is ${MAX_IMAGE_BYTES / (1024 * 1024)}MB.`,
+		);
+	}
+
+	return {
+		base64: readFileSync(filePath).toString("base64"),
+		source: "file",
+		filePath,
+		name: basename(filePath, ext),
+	};
+}

--- a/src/core/image-input.ts
+++ b/src/core/image-input.ts
@@ -26,7 +26,7 @@ export function looksLikeImageFilePath(value: string): boolean {
 	const s = stripWrappingQuotes(value.trim());
 	if (!s || /^data:/i.test(s)) return false;
 	if (/^file:/i.test(s)) return true;
-	return IMAGE_EXT.test(pathWithoutQuery(s));
+	return IMAGE_EXT.test(s);
 }
 
 /**
@@ -46,14 +46,15 @@ export function resolveImageInput(imageData: string): ResolvedImageInput {
 		trimmed,
 	);
 	if (dataUrl) {
-		return { base64: dataUrl[1].replace(/\s/g, ""), source: "data-url" };
+		const base64 = normalizeBase64(dataUrl[1]);
+		return { base64, source: "data-url" };
 	}
 
 	if (looksLikeImageFilePath(trimmed)) {
 		return readImageFile(trimmed);
 	}
 
-	return { base64: trimmed.replace(/\s/g, ""), source: "base64" };
+	return { base64: normalizeBase64(trimmed), source: "base64" };
 }
 
 function stripWrappingQuotes(value: string): string {
@@ -66,8 +67,20 @@ function stripWrappingQuotes(value: string): string {
 	return value;
 }
 
-function pathWithoutQuery(value: string): string {
-	return value.split(/[?#]/)[0];
+function normalizeBase64(value: string): string {
+	const base64 = value.replace(/\s/g, "");
+	const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+	const decodedBytes = Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+	assertImageSize(decodedBytes);
+	return base64;
+}
+
+function assertImageSize(bytes: number): void {
+	if (bytes > MAX_IMAGE_BYTES) {
+		throw new Error(
+			`Image is too large (${Math.ceil(bytes / (1024 * 1024))}MB). Maximum is ${MAX_IMAGE_BYTES / (1024 * 1024)}MB.`,
+		);
+	}
 }
 
 function readImageFile(rawPath: string): ResolvedImageInput {
@@ -109,11 +122,7 @@ function readImageFile(rawPath: string): ResolvedImageInput {
 	}
 
 	const stat = statSync(filePath);
-	if (stat.size > MAX_IMAGE_BYTES) {
-		throw new Error(
-			`Image is too large (${Math.round(stat.size / (1024 * 1024))}MB). Maximum is ${MAX_IMAGE_BYTES / (1024 * 1024)}MB.`,
-		);
-	}
+	assertImageSize(stat.size);
 
 	return {
 		base64: readFileSync(filePath).toString("base64"),

--- a/src/core/websocket-connector.ts
+++ b/src/core/websocket-connector.ts
@@ -400,8 +400,14 @@ export class WebSocketConnector implements IFigmaConnector {
   // Image fill
   // ============================================================================
 
-  async setImageFill(nodeIds: string[], imageData: string, scaleMode = 'FILL'): Promise<any> {
-    return this.wsServer.sendCommand('SET_IMAGE_FILL', { nodeIds, imageData, scaleMode }, 60000);
+  async setImageFill(nodeIds: string[], imageData: string, scaleMode = 'FILL', name?: string): Promise<any> {
+    const params: { nodeIds: string[]; imageData: string; scaleMode: string; name?: string } = {
+      nodeIds,
+      imageData,
+      scaleMode,
+    };
+    if (name) params.name = name;
+    return this.wsServer.sendCommand('SET_IMAGE_FILL', params, 60000);
   }
 
   // ============================================================================

--- a/src/core/write-tools.ts
+++ b/src/core/write-tools.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { resolveImageInput } from "./image-input.js";
 import { createChildLogger } from "./logger.js";
 
 const logger = createChildLogger({ component: "write-tools" });
@@ -1850,25 +1851,58 @@ After instantiating components, use figma_take_screenshot to verify the result l
 		},
 	);
 
-	// Tool: Set Image Fill on nodes
+	// Tool: Set Image Fill on nodes (also inserts a new image when nodeIds is omitted)
 	server.tool(
 		"figma_set_image_fill",
-		"Set an image fill on one or more Figma nodes. The imageData parameter accepts a base64-encoded " +
-		"image string (JPEG/PNG). The image is decoded in the browser bridge and passed " +
-		"as raw bytes to the Figma plugin. Requires Desktop Bridge plugin.",
+		"Insert a PNG/JPEG/GIF into Figma, or set an image fill on existing nodes. " +
+		"This is the way to put a local image on the canvas — clipboard paste is not supported. " +
+		"imageData accepts (1) an absolute local file path (Local Mode only; Windows paths like " +
+		"C:/Users/me/photo.png work) or (2) base64-encoded image bytes, optionally as a " +
+		"data:image/...;base64 URL. Omit nodeIds to paste the image onto the current page as a new " +
+		"rectangle sized to the image (selected and zoomed into). Pass nodeIds to apply the image as " +
+		"a fill on existing frames/shapes. Requires Desktop Bridge plugin.",
 		{
-			nodeIds: z.array(z.string()).describe("Array of node IDs to apply the image fill to"),
-			imageData: z.string().describe("Base64-encoded image data (JPEG/PNG)"),
-			scaleMode: z.enum(["FILL", "FIT", "CROP", "TILE"]).optional().describe("How the image fills the node (default: FILL)"),
+			nodeIds: z
+				.array(z.string())
+				.optional()
+				.describe(
+					"Node IDs to apply the image fill to. Omit or pass [] to insert a new image on the current page.",
+				),
+			imageData: z
+				.string()
+				.describe(
+					"Absolute local file path to a PNG/JPEG/GIF (Local Mode) or base64-encoded image data (optionally a data URL).",
+				),
+			scaleMode: z
+				.enum(["FILL", "FIT", "CROP", "TILE"])
+				.optional()
+				.describe("How the image fills the node (default: FILL)"),
+			name: z
+				.string()
+				.optional()
+				.describe(
+					"Layer name for a newly created image node. Defaults to the file name when imageData is a path.",
+				),
 		},
-		async ({ nodeIds, imageData, scaleMode }) => {
+		async ({ nodeIds, imageData, scaleMode, name }) => {
 			try {
+				const resolved = resolveImageInput(imageData);
 				const connector = await getDesktopConnector();
-				const result = await connector.setImageFill(nodeIds, imageData, scaleMode || "FILL");
+				const ids = nodeIds && nodeIds.length ? nodeIds : [];
+				const result = await connector.setImageFill(
+					ids,
+					resolved.base64,
+					scaleMode || "FILL",
+					name || resolved.name,
+				);
 
 				if (!result.success) {
 					throw new Error(result.error || "Failed to set image fill");
 				}
+
+				const createdNode = result.nodes && result.nodes[0] && result.nodes[0].created
+					? result.nodes[0]
+					: null;
 
 				return {
 					content: [
@@ -1876,9 +1910,13 @@ After instantiating components, use figma_take_screenshot to verify the result l
 							type: "text" as const,
 							text: JSON.stringify({
 								success: true,
-								message: `Image fill applied to ${result.updatedCount || 0} node(s)`,
+								message: createdNode
+									? `Inserted image "${createdNode.name}" (${createdNode.width}×${createdNode.height}) on the current page`
+									: `Image fill applied to ${result.updatedCount || 0} node(s)`,
 								imageHash: result.imageHash,
 								nodes: result.nodes,
+								created: Boolean(createdNode),
+								source: resolved.source,
 							}),
 						},
 					],

--- a/tests/image-input.test.ts
+++ b/tests/image-input.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+	looksLikeImageFilePath,
+	resolveImageInput,
+} from "../src/core/image-input";
+
+/** 1×1 PNG */
+const PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+const PNG_BYTES = Buffer.from(PNG_BASE64, "base64");
+
+describe("looksLikeImageFilePath", () => {
+	it("detects Windows, Unix, UNC, and file:// paths", () => {
+		expect(looksLikeImageFilePath("C:\\Users\\me\\photo.png")).toBe(true);
+		expect(looksLikeImageFilePath("C:/Users/me/photo.jpg")).toBe(true);
+		expect(looksLikeImageFilePath("/tmp/hero-image.jpeg")).toBe(true);
+		expect(looksLikeImageFilePath("\\\\server\\share\\shot.gif")).toBe(true);
+		expect(looksLikeImageFilePath("file:///C:/Users/me/photo.png")).toBe(true);
+		expect(looksLikeImageFilePath("photo.png")).toBe(true);
+	});
+
+	it("does not treat JPEG or PNG base64 as a path", () => {
+		expect(looksLikeImageFilePath("/9j/4AAQSkZJRgABAQAAAQABAAD")).toBe(false);
+		expect(looksLikeImageFilePath(PNG_BASE64)).toBe(false);
+	});
+
+	it("ignores data URLs and unsupported extensions", () => {
+		expect(looksLikeImageFilePath(`data:image/png;base64,${PNG_BASE64}`)).toBe(
+			false,
+		);
+		expect(looksLikeImageFilePath("/tmp/vector.svg")).toBe(false);
+		expect(looksLikeImageFilePath("C:\\Users\\me\\photo.webp")).toBe(false);
+	});
+});
+
+describe("resolveImageInput", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "figma-image-input-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("passes through base64", () => {
+		const resolved = resolveImageInput(`  ${PNG_BASE64}  \n`);
+		expect(resolved.source).toBe("base64");
+		expect(resolved.base64).toBe(PNG_BASE64);
+	});
+
+	it("strips a data URL prefix", () => {
+		const resolved = resolveImageInput(`data:image/png;base64,${PNG_BASE64}`);
+		expect(resolved.source).toBe("data-url");
+		expect(resolved.base64).toBe(PNG_BASE64);
+	});
+
+	it("reads a local PNG and names the layer after the file", () => {
+		const filePath = join(dir, "hero-image.png");
+		writeFileSync(filePath, PNG_BYTES);
+
+		const resolved = resolveImageInput(filePath);
+		expect(resolved.source).toBe("file");
+		expect(resolved.base64).toBe(PNG_BASE64);
+		expect(resolved.name).toBe("hero-image");
+		expect(resolved.filePath).toBe(filePath);
+	});
+
+	it("reads a file:// URL and strips wrapping quotes", () => {
+		const filePath = join(dir, "quoted.png");
+		writeFileSync(filePath, PNG_BYTES);
+		const url = pathToFileURL(filePath).href;
+
+		const resolved = resolveImageInput(`"${url}"`);
+		expect(resolved.source).toBe("file");
+		expect(resolved.base64).toBe(PNG_BASE64);
+	});
+
+	it("throws a Local Mode hint when the file is missing", () => {
+		expect(() =>
+			resolveImageInput("C:\\Users\\nobody\\missing-photo.png"),
+		).toThrow(/Image file not found/);
+		expect(() =>
+			resolveImageInput("C:\\Users\\nobody\\missing-photo.png"),
+		).toThrow(/Local Mode/);
+	});
+
+	it("rejects empty input", () => {
+		expect(() => resolveImageInput("   ")).toThrow(/imageData is required/);
+	});
+});

--- a/tests/image-input.test.ts
+++ b/tests/image-input.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import {
+	MAX_IMAGE_BYTES,
 	looksLikeImageFilePath,
 	resolveImageInput,
 } from "../src/core/image-input";
@@ -21,6 +22,8 @@ describe("looksLikeImageFilePath", () => {
 		expect(looksLikeImageFilePath("\\\\server\\share\\shot.gif")).toBe(true);
 		expect(looksLikeImageFilePath("file:///C:/Users/me/photo.png")).toBe(true);
 		expect(looksLikeImageFilePath("photo.png")).toBe(true);
+		expect(looksLikeImageFilePath("C:\\Users\\me\\hero#final.png")).toBe(true);
+		expect(looksLikeImageFilePath("/tmp/hero?final.png")).toBe(true);
 	});
 
 	it("does not treat JPEG or PNG base64 as a path", () => {
@@ -71,6 +74,16 @@ describe("resolveImageInput", () => {
 		expect(resolved.filePath).toBe(filePath);
 	});
 
+	it("reads image paths containing a hash character", () => {
+		const filePath = join(dir, "hero#final.png");
+		writeFileSync(filePath, PNG_BYTES);
+
+		const resolved = resolveImageInput(filePath);
+		expect(resolved.source).toBe("file");
+		expect(resolved.base64).toBe(PNG_BASE64);
+		expect(resolved.name).toBe("hero#final");
+	});
+
 	it("reads a file:// URL and strips wrapping quotes", () => {
 		const filePath = join(dir, "quoted.png");
 		writeFileSync(filePath, PNG_BYTES);
@@ -92,5 +105,14 @@ describe("resolveImageInput", () => {
 
 	it("rejects empty input", () => {
 		expect(() => resolveImageInput("   ")).toThrow(/imageData is required/);
+	});
+
+	it("rejects oversized raw base64 and data URLs", () => {
+		const oversizedBase64 = Buffer.alloc(MAX_IMAGE_BYTES + 1).toString("base64");
+
+		expect(() => resolveImageInput(oversizedBase64)).toThrow(/Image is too large/);
+		expect(() =>
+			resolveImageInput(`data:image/png;base64,${oversizedBase64}`),
+		).toThrow(/Image is too large/);
 	});
 });

--- a/tests/set-image-fill.test.ts
+++ b/tests/set-image-fill.test.ts
@@ -5,6 +5,9 @@
  * input validation, and error handling.
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 describe('figma_set_image_fill', () => {
 	// ========================================================================
 	// Plugin handler (code.js message handling)
@@ -138,7 +141,7 @@ describe('figma_set_image_fill', () => {
 	// ========================================================================
 
 	describe('tool schema', () => {
-		it('should require nodeIds as string array', () => {
+		it('should accept nodeIds as an optional string array', () => {
 			const validParams = {
 				nodeIds: ['1:2', '3:4'],
 				imageData: 'base64string',
@@ -248,5 +251,119 @@ describe('figma_set_image_fill', () => {
 			const resolved = params.nodeIds || params.nodeId;
 			expect(resolved).toBe('1:2');
 		});
+	});
+});
+describe("code.js SET_IMAGE_FILL handler", () => {
+	const codeJsSource = readFileSync(
+		join(__dirname, "../figma-desktop-bridge/code.js"),
+		"utf-8",
+	);
+
+	function extractHandler() {
+		const start = codeJsSource.indexOf(
+			"else if (msg.type === 'SET_IMAGE_FILL')",
+		);
+		if (start === -1) throw new Error("SET_IMAGE_FILL handler not found");
+		const endMarker = codeJsSource.indexOf("// SET_NODE_STROKES", start);
+		const block = codeJsSource.slice(
+			start,
+			codeJsSource.lastIndexOf("}", endMarker) + 1,
+		);
+		return new Function(
+			"figma",
+			"msg",
+			`return (async () => { if (false) {} ${block} })();`,
+		);
+	}
+
+	function makeSandbox() {
+		const posted: any[] = [];
+		const rect = {
+			id: "rect:1",
+			name: "",
+			x: 0,
+			y: 0,
+			width: 100,
+			height: 100,
+			fills: [] as any[],
+			resize(width: number, height: number) {
+				this.width = width;
+				this.height = height;
+			},
+		};
+		const target = {
+			id: "1:2",
+			name: "Frame",
+			type: "FRAME",
+			fills: [] as any[],
+		};
+		const figma = {
+			createImage: (bytes: Uint8Array) => ({
+				hash: "imghash",
+				bytes,
+				getSizeAsync: async () => ({ width: 200, height: 80 }),
+			}),
+			createRectangle: () => rect,
+			getNodeByIdAsync: async (id: string) => (id === "1:2" ? target : null),
+			currentPage: { selection: [] as any[] },
+			viewport: {
+				center: { x: 500, y: 400 },
+				scrollAndZoomIntoView: jest.fn(),
+			},
+			ui: { postMessage: (m: any) => posted.push(m) },
+		};
+		return { figma, posted, rect, target };
+	}
+
+	it("inserts a new rectangle sized to the image when nodeIds is empty", async () => {
+		const { figma, posted, rect } = makeSandbox();
+		const run = extractHandler();
+		await run(figma, {
+			type: "SET_IMAGE_FILL",
+			requestId: "r1",
+			imageBytes: [1, 2, 3],
+			nodeIds: [],
+			name: "hero",
+		});
+
+		expect(rect.name).toBe("hero");
+		expect(rect.width).toBe(200);
+		expect(rect.height).toBe(80);
+		expect(rect.x).toBe(400);
+		expect(rect.y).toBe(360);
+		expect(figma.currentPage.selection).toEqual([rect]);
+		expect(posted[0]).toMatchObject({
+			type: "SET_IMAGE_FILL_RESULT",
+			success: true,
+			imageHash: "imghash",
+			updatedCount: 1,
+			nodes: [
+				{
+					id: "rect:1",
+					name: "hero",
+					created: true,
+					width: 200,
+					height: 80,
+				},
+			],
+		});
+	});
+
+	it("applies an image fill to existing nodes when nodeIds are provided", async () => {
+		const { figma, posted, target } = makeSandbox();
+		const run = extractHandler();
+		await run(figma, {
+			type: "SET_IMAGE_FILL",
+			requestId: "r2",
+			imageBytes: [1, 2, 3],
+			nodeIds: ["1:2"],
+			scaleMode: "FIT",
+		});
+
+		expect(target.fills).toEqual([
+			{ type: "IMAGE", scaleMode: "FIT", imageHash: "imghash" },
+		]);
+		expect(posted[0].nodes[0].created).toBeUndefined();
+		expect(posted[0].updatedCount).toBe(1);
 	});
 });

--- a/tests/write-tools.test.ts
+++ b/tests/write-tools.test.ts
@@ -334,6 +334,87 @@ describe("Write Tools", () => {
 	});
 
 	// ========================================================================
+	// figma_set_image_fill — local file + insert-as-new-node
+	// ========================================================================
+
+	describe("figma_set_image_fill", () => {
+		const pngBase64 =
+			"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+		it("sends decoded base64 and empty nodeIds when inserting a new image", async () => {
+			mockConnector.setImageFill.mockResolvedValue({
+				success: true,
+				imageHash: "hash123",
+				updatedCount: 1,
+				nodes: [{ id: "n1", name: "Image", created: true, width: 1, height: 1 }],
+			});
+
+			const tool = server._getTool("figma_set_image_fill");
+			const result = await tool.handler({ imageData: pngBase64 });
+			const parsed = parseResult(result);
+
+			expect(mockConnector.setImageFill).toHaveBeenCalledWith(
+				[],
+				pngBase64,
+				"FILL",
+				undefined,
+			);
+			expect(parsed.created).toBe(true);
+			expect(parsed.message).toContain("Inserted image");
+		});
+
+		it("reads a local file path and uses the file name as the layer name", async () => {
+			const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+			const { tmpdir } = await import("node:os");
+			const dir = mkdtempSync(join(tmpdir(), "figma-set-image-fill-"));
+			const filePath = join(dir, "avatar.png");
+			writeFileSync(filePath, Buffer.from(pngBase64, "base64"));
+
+			try {
+				const tool = server._getTool("figma_set_image_fill");
+				await tool.handler({ imageData: filePath, nodeIds: ["1:2"] });
+
+				expect(mockConnector.setImageFill).toHaveBeenCalledWith(
+					["1:2"],
+					pngBase64,
+					"FILL",
+					"avatar",
+				);
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		});
+
+		it("returns a file-not-found error without calling the plugin", async () => {
+			const tool = server._getTool("figma_set_image_fill");
+			const result = await tool.handler({
+				imageData: "C:\\Users\\nobody\\does-not-exist.png",
+			});
+			const parsed = parseResult(result);
+
+			expect(result.isError).toBe(true);
+			expect(parsed.error).toMatch(/Image file not found/);
+			expect(mockConnector.setImageFill).not.toHaveBeenCalled();
+		});
+
+		it("applies a fill to existing nodes when nodeIds are provided", async () => {
+			const tool = server._getTool("figma_set_image_fill");
+			await tool.handler({
+				nodeIds: ["1:2", "3:4"],
+				imageData: pngBase64,
+				scaleMode: "FIT",
+			});
+
+			expect(mockConnector.setImageFill).toHaveBeenCalledWith(
+				["1:2", "3:4"],
+				pngBase64,
+				"FIT",
+				undefined,
+			);
+		});
+	});
+
+	// ========================================================================
 	// Error response consistency
 	// ========================================================================
 


### PR DESCRIPTION
## Summary

Extends `figma_set_image_fill` so it can insert images directly onto the current Figma page, in addition to applying image fills to existing nodes.

## Changes

  - Accept absolute PNG, JPEG, and GIF file paths in Local Mode
  - Continue supporting raw base64 and `data:image/...;base64` URLs
  - Make `nodeIds` optional:
    - When provided, apply the image fill to existing nodes
    - When omitted or empty, create an image-sized rectangle on the current page
  - Center, select, and zoom to newly inserted images
  - Use the source filename as the default layer name
  - Support an explicit `name` for newly created layers
  - Apply a consistent 15 MiB input limit across files, base64, and data URLs
  - Handle valid filenames containing `#` or `?`
  - Update Desktop Bridge connectors, documentation, and tests

## Testing

  - Full test suite: 1,490 passed, 7 skipped
  - Local TypeScript build passed
  - Cloud TypeScript build passed
  - Biome lint passed
  - Cloudflare dry-run bundle succeeded

## Usage

Insert a local image:

```javascript
figma_set_image_fill({
  imageData: "C:\\Users\\me\\Pictures\\hero.png"
})

Apply an image to existing nodes:

figma_set_image_fill({
  nodeIds: ["123:456"],
  imageData: "/tmp/hero.jpg",
  scaleMode: "FILL"
})